### PR TITLE
Add MMIO allocation API

### DIFF
--- a/MacHyperVSupport/VMBusController/HyperVVMBusController.cpp
+++ b/MacHyperVSupport/VMBusController/HyperVVMBusController.cpp
@@ -211,7 +211,7 @@ bool HyperVVMBusController::start(IOService *provider) {
   pciService->release();
   DBGLOG("HyperVPCIRoot is now loaded");
   
-
+  walkResources(OSDynamicCast(IOACPIPlatformDevice, provider));
   
   //
   // Setup hypercalls.

--- a/MacHyperVSupport/VMBusController/HyperVVMBusController.hpp
+++ b/MacHyperVSupport/VMBusController/HyperVVMBusController.hpp
@@ -22,6 +22,9 @@ extern "C" {
 #include <IOKit/IOBufferMemoryDescriptor.h>
 #include <IOKit/IOLocks.h>
 
+#include <IOKit/acpi/IOACPIPlatformDevice.h>
+#include <IOKit/acpi/IOACPITypes.h>
+
 #include "HyperV.hpp"
 #include "VMBus.hpp"
 #include "VMBusDriver.hpp"
@@ -163,6 +166,11 @@ private:
   //
   bool configureVMBusChannelGpadl(VMBusChannel *channel, HyperVDMABuffer *buffer, UInt32 *gpadlHandle);
   bool configureVMBusChannel(VMBusChannel *channel);
+  
+  //
+  // ACPI resource to IODeviceMemory.
+  //
+  void walkResources(IOACPIPlatformDevice *provider);
   
 public:
   //

--- a/MacHyperVSupport/VMBusDevice/HyperVVMBusDevice.cpp
+++ b/MacHyperVSupport/VMBusDevice/HyperVVMBusDevice.cpp
@@ -356,8 +356,7 @@ IODeviceMemory* HyperVVMBusDevice::allocateMmio(size_t start, size_t size, size_
     for (int i = 0; i < deviceMemoryArray->getCount(); i++) {
       IODeviceMemory* currentDeviceMemory = (IODeviceMemory*)(deviceMemoryArray->getObject(i));
       if (currentDeviceMemory != NULL) {
-        IOPhysicalAddress currentDeviceMemoryStart = (currentDeviceMemory->getPhysicalAddress() + align - 1) & ~(align - 1);
-        return (IODeviceMemory*)IOMemoryDescriptor::withAddressRange(currentDeviceMemoryStart, round_page(currentDeviceMemoryStart+size), kIODirectionInOut | kIOMemoryPhysicallyContiguous | kIOMapInhibitCache | kIOMemoryMapperNone, kernel_task);
+        return IODeviceMemory::withSubRange(currentDeviceMemory, (start + align - 1) & ~(align - 1), size);
       }
     }
   }

--- a/MacHyperVSupport/VMBusDevice/HyperVVMBusDevice.cpp
+++ b/MacHyperVSupport/VMBusDevice/HyperVVMBusDevice.cpp
@@ -348,3 +348,18 @@ void HyperVVMBusDevice::wakeTransaction(UInt64 transactionId) {
   }
   IOLockUnlock(vmbusRequestsLock);
 }
+
+IODeviceMemory* HyperVVMBusDevice::allocateMmio(size_t start, size_t size, size_t align, bool allowFbOverlap) {
+  if (allowFbOverlap) { DBGLOG("allowFbOverlap not currently implemented"); }
+  OSArray* deviceMemoryArray = vmbusProvider->getProvider()->getDeviceMemory();
+  if (deviceMemoryArray != NULL) {
+    for (int i = 0; i < deviceMemoryArray->getCount(); i++) {
+      IODeviceMemory* currentDeviceMemory = (IODeviceMemory*)(deviceMemoryArray->getObject(i));
+      if (currentDeviceMemory != NULL) {
+        IOPhysicalAddress currentDeviceMemoryStart = (currentDeviceMemory->getPhysicalAddress() + align - 1) & ~(align - 1);
+        return (IODeviceMemory*)IOMemoryDescriptor::withAddressRange(currentDeviceMemoryStart, round_page(currentDeviceMemoryStart+size), kIODirectionInOut | kIOMemoryPhysicallyContiguous | kIOMapInhibitCache | kIOMemoryMapperNone, kernel_task);
+      }
+    }
+  }
+  return NULL;
+}

--- a/MacHyperVSupport/VMBusDevice/HyperVVMBusDevice.hpp
+++ b/MacHyperVSupport/VMBusDevice/HyperVVMBusDevice.hpp
@@ -125,7 +125,10 @@ public:
   bool getPendingTransaction(UInt64 transactionId, void **buffer, UInt32 *bufferLength);
   void wakeTransaction(UInt64 transactionId);
   
-  
+  //
+  // MMIO allocation function.
+  //
+  IODeviceMemory* allocateMmio(size_t start, size_t size, size_t align, bool allowFbOverlap);
 };
 
 #endif


### PR DESCRIPTION
Opening as a draft PR, please provide feedback.

- Changes to HyperVVMBusController:
	* Walk ACPI resources (in acpi-address-spaces property) to set IODeviceMemory.
		* Parsing ACPI _CRS directly is preferred, however this will suffice.
		* Merging adjacent memory regions may be implemented to bring in line with Linux/FreeBSD API.

- Changes to HyperVVMBusDevice:
	* MMIO allocation API added.
		* allowFbOverlap option remains to be implemented.
		* Needed for Synthetic Video improvements & Synthetic PCI driver.