### PR TITLE
Implement Hyper-V File Copy Integration Service

### DIFF
--- a/MacHyperVSupport.xcodeproj/project.pbxproj
+++ b/MacHyperVSupport.xcodeproj/project.pbxproj
@@ -182,7 +182,6 @@
 		817C3CB928EB754C002EA298 /* HyperVFileCopy.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 817C3CB628EB754C002EA298 /* HyperVFileCopy.hpp */; };
 		817C3CBA28EB755E002EA298 /* HyperVFileCopy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 817C3CB528EB754C002EA298 /* HyperVFileCopy.cpp */; };
 		817C3CBB28EB7561002EA298 /* HyperVFileCopy.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 817C3CB628EB754C002EA298 /* HyperVFileCopy.hpp */; };
-		817C3CBD28EBD791002EA298 /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 817C3CBC28EBD77E002EA298 /* libiconv.tbd */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -340,7 +339,6 @@
 		817C3CB428EB754C002EA298 /* HyperVFileCopyRegs.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = HyperVFileCopyRegs.hpp; sourceTree = "<group>"; };
 		817C3CB528EB754C002EA298 /* HyperVFileCopy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HyperVFileCopy.cpp; sourceTree = "<group>"; };
 		817C3CB628EB754C002EA298 /* HyperVFileCopy.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = HyperVFileCopy.hpp; sourceTree = "<group>"; };
-		817C3CBC28EBD77E002EA298 /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -348,7 +346,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				817C3CBD28EBD791002EA298 /* libiconv.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -569,7 +566,6 @@
 		41BE4112263EDEA10018C52B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				817C3CBC28EBD77E002EA298 /* libiconv.tbd */,
 				41BE4113263EDEA10018C52B /* libkmod.a */,
 			);
 			name = Frameworks;

--- a/MacHyperVSupport.xcodeproj/project.pbxproj
+++ b/MacHyperVSupport.xcodeproj/project.pbxproj
@@ -178,6 +178,10 @@
 		41F9B8F8284983FF00E0DCB2 /* HyperVPCIBridgePrivate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 41F9B8F7284983FF00E0DCB2 /* HyperVPCIBridgePrivate.cpp */; };
 		41F9B8FF284BA20700E0DCB2 /* HyperVModuleDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 41F9B8FD284BA20700E0DCB2 /* HyperVModuleDevice.cpp */; };
 		41F9B900284BA20700E0DCB2 /* HyperVModuleDevice.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 41F9B8FE284BA20700E0DCB2 /* HyperVModuleDevice.hpp */; };
+		817C3CB828EB754C002EA298 /* HyperVFileCopy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 817C3CB528EB754C002EA298 /* HyperVFileCopy.cpp */; };
+		817C3CB928EB754C002EA298 /* HyperVFileCopy.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 817C3CB628EB754C002EA298 /* HyperVFileCopy.hpp */; };
+		817C3CBA28EB755E002EA298 /* HyperVFileCopy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 817C3CB528EB754C002EA298 /* HyperVFileCopy.cpp */; };
+		817C3CBB28EB7561002EA298 /* HyperVFileCopy.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 817C3CB628EB754C002EA298 /* HyperVFileCopy.hpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -332,6 +336,9 @@
 		41F9B8FD284BA20700E0DCB2 /* HyperVModuleDevice.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HyperVModuleDevice.cpp; sourceTree = "<group>"; };
 		41F9B8FE284BA20700E0DCB2 /* HyperVModuleDevice.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = HyperVModuleDevice.hpp; sourceTree = "<group>"; };
 		41F9B903284BA4AB00E0DCB2 /* AppleACPIRange.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = AppleACPIRange.hpp; sourceTree = "<group>"; };
+		817C3CB428EB754C002EA298 /* HyperVFileCopyRegs.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = HyperVFileCopyRegs.hpp; sourceTree = "<group>"; };
+		817C3CB528EB754C002EA298 /* HyperVFileCopy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HyperVFileCopy.cpp; sourceTree = "<group>"; };
+		817C3CB628EB754C002EA298 /* HyperVFileCopy.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = HyperVFileCopy.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -446,6 +453,7 @@
 				418F052726483CAE00E1D14C /* HyperVIC.hpp */,
 				418F052026483C8300E1D14C /* HyperVICService.cpp */,
 				418F052126483C8300E1D14C /* HyperVICService.hpp */,
+				817C3CB328EB754C002EA298 /* FileCopy */,
 				411FB8FC289DD2FF0063EF4E /* Heartbeat */,
 				41B3717228960AA000D348B5 /* Shutdown */,
 				417CEDD128E22C3900D0F6A8 /* TimeSync */,
@@ -714,6 +722,16 @@
 			path = ModuleDevice;
 			sourceTree = "<group>";
 		};
+		817C3CB328EB754C002EA298 /* FileCopy */ = {
+			isa = PBXGroup;
+			children = (
+				817C3CB528EB754C002EA298 /* HyperVFileCopy.cpp */,
+				817C3CB628EB754C002EA298 /* HyperVFileCopy.hpp */,
+				817C3CB428EB754C002EA298 /* HyperVFileCopyRegs.hpp */,
+			);
+			path = FileCopy;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -740,6 +758,7 @@
 				41F9B8F12849792200E0DCB2 /* HyperVPCIBridge.hpp in Headers */,
 				41F2E3FB2665B42200CE26CE /* kern_policy.hpp in Headers */,
 				41F2E3FE2665B42200CE26CE /* kern_iokit.hpp in Headers */,
+				817C3CB928EB754C002EA298 /* HyperVFileCopy.hpp in Headers */,
 				41F2E4102665B42200CE26CE /* kern_patcher.hpp in Headers */,
 				41F2E44C2666F37B00CE26CE /* HyperVPCIProvider.hpp in Headers */,
 				41F2E40B2665B42200CE26CE /* x86.h in Headers */,
@@ -790,6 +809,7 @@
 				41BF45DF288CDF1200813670 /* sparc.h in Headers */,
 				41BF45E0288CDF1200813670 /* platform.h in Headers */,
 				41BF45E1288CDF1200813670 /* HyperVICService.hpp in Headers */,
+				817C3CBB28EB7561002EA298 /* HyperVFileCopy.hpp in Headers */,
 				41BF45E2288CDF1200813670 /* ppc.h in Headers */,
 				41BF45E3288CDF1200813670 /* kern_version.hpp in Headers */,
 				41BF45E4288CDF1200813670 /* HyperVGraphics.hpp in Headers */,
@@ -1005,6 +1025,7 @@
 			files = (
 				41F2E45C26683B2C00CE26CE /* HyperVPCIRoot.cpp in Sources */,
 				414678B728C4F0E5000E8F83 /* HyperVInterruptController.cpp in Sources */,
+				817C3CB828EB754C002EA298 /* HyperVFileCopy.cpp in Sources */,
 				41F2E4202665B42900CE26CE /* plugin_start.cpp in Sources */,
 				41F2E4282665B4C100CE26CE /* kern_start.cpp in Sources */,
 				412E10A028C589DF00B8A699 /* HyperVVMBus.cpp in Sources */,
@@ -1045,6 +1066,7 @@
 			files = (
 				41BF4609288CDF1200813670 /* HyperVPCIRoot.cpp in Sources */,
 				414678B828C4F0E5000E8F83 /* HyperVInterruptController.cpp in Sources */,
+				817C3CBA28EB755E002EA298 /* HyperVFileCopy.cpp in Sources */,
 				41BF460A288CDF1200813670 /* plugin_start.cpp in Sources */,
 				41BF460B288CDF1200813670 /* kern_start.cpp in Sources */,
 				412E10A128C589DF00B8A699 /* HyperVVMBus.cpp in Sources */,

--- a/MacHyperVSupport.xcodeproj/project.pbxproj
+++ b/MacHyperVSupport.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		817C3CB928EB754C002EA298 /* HyperVFileCopy.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 817C3CB628EB754C002EA298 /* HyperVFileCopy.hpp */; };
 		817C3CBA28EB755E002EA298 /* HyperVFileCopy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 817C3CB528EB754C002EA298 /* HyperVFileCopy.cpp */; };
 		817C3CBB28EB7561002EA298 /* HyperVFileCopy.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 817C3CB628EB754C002EA298 /* HyperVFileCopy.hpp */; };
+		817C3CBD28EBD791002EA298 /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 817C3CBC28EBD77E002EA298 /* libiconv.tbd */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -339,6 +340,7 @@
 		817C3CB428EB754C002EA298 /* HyperVFileCopyRegs.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = HyperVFileCopyRegs.hpp; sourceTree = "<group>"; };
 		817C3CB528EB754C002EA298 /* HyperVFileCopy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HyperVFileCopy.cpp; sourceTree = "<group>"; };
 		817C3CB628EB754C002EA298 /* HyperVFileCopy.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = HyperVFileCopy.hpp; sourceTree = "<group>"; };
+		817C3CBC28EBD77E002EA298 /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -346,6 +348,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				817C3CBD28EBD791002EA298 /* libiconv.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -566,6 +569,7 @@
 		41BE4112263EDEA10018C52B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				817C3CBC28EBD77E002EA298 /* libiconv.tbd */,
 				41BE4113263EDEA10018C52B /* libkmod.a */,
 			);
 			name = Frameworks;

--- a/MacHyperVSupport/Controller/HyperVController.cpp
+++ b/MacHyperVSupport/Controller/HyperVController.cpp
@@ -357,3 +357,7 @@ IOReturn HyperVController::notifyUserClient(HyperVUserClientNotificationType typ
   }
   return _userClientInstance->notifyClientApplication(type, data, dataLength);
 }
+
+void HyperVController::registerUserClientDriverCallback(HyperVUserClientMethod index, mach_vm_address_t callback) {
+  HyperVUserClient::registerDriverCallback(index, callback);
+}

--- a/MacHyperVSupport/Controller/HyperVController.cpp
+++ b/MacHyperVSupport/Controller/HyperVController.cpp
@@ -358,6 +358,16 @@ IOReturn HyperVController::notifyUserClient(HyperVUserClientNotificationType typ
   return _userClientInstance->notifyClientApplication(type, data, dataLength);
 }
 
-void HyperVController::registerUserClientDriverCallback(HyperVUserClientMethod index, mach_vm_address_t callback) {
-  HyperVUserClient::registerDriverCallback(index, callback);
+bool HyperVController::registerUserClientDriver(IOService *driver) {
+  if (_userClientInstance == nullptr) {
+    return false;
+  }
+  return _userClientInstance->registerDriver(driver);
+}
+
+bool HyperVController::deregisterUserClientDriver(IOService *driver) {
+  if (_userClientInstance == nullptr) {
+    return false;
+  }
+  return _userClientInstance->registerDriver(driver);
 }

--- a/MacHyperVSupport/Controller/HyperVController.hpp
+++ b/MacHyperVSupport/Controller/HyperVController.hpp
@@ -114,6 +114,7 @@ public:
   bool addInterruptProperties(OSDictionary *dict, UInt32 interruptVector);
   bool checkUserClient() { return _userClientInstance != nullptr; }
   IOReturn notifyUserClient(HyperVUserClientNotificationType type, void *data, UInt32 dataLength);
+  void registerUserClientDriverCallback(HyperVUserClientMethod index, mach_vm_address_t callback);
   
   //
   // Hypercalls/interrupts.

--- a/MacHyperVSupport/Controller/HyperVController.hpp
+++ b/MacHyperVSupport/Controller/HyperVController.hpp
@@ -114,7 +114,8 @@ public:
   bool addInterruptProperties(OSDictionary *dict, UInt32 interruptVector);
   bool checkUserClient() { return _userClientInstance != nullptr; }
   IOReturn notifyUserClient(HyperVUserClientNotificationType type, void *data, UInt32 dataLength);
-  void registerUserClientDriverCallback(HyperVUserClientMethod index, mach_vm_address_t callback);
+  bool registerUserClientDriver(IOService *driver);
+  bool deregisterUserClientDriver(IOService *driver);
   
   //
   // Hypercalls/interrupts.

--- a/MacHyperVSupport/Controller/HyperVUserClient.cpp
+++ b/MacHyperVSupport/Controller/HyperVUserClient.cpp
@@ -41,12 +41,12 @@ bool HyperVUserClient::start(IOService *provider) {
   //
   // Populate notification message info.
   //
-  _notificationMsg.header.msgh_bits        = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND, 0);
-  _notificationMsg.header.msgh_size        = sizeof (_notificationMsg);
-  _notificationMsg.header.msgh_remote_port = MACH_PORT_NULL;
-  _notificationMsg.header.msgh_local_port  = MACH_PORT_NULL;
-  _notificationMsg.header.msgh_reserved    = 0;
-  _notificationMsg.header.msgh_id          = 0;
+  _notificationMsg.standard.header.msgh_bits        = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND, 0);
+  _notificationMsg.standard.header.msgh_size        = sizeof (_notificationMsg.standard);
+  _notificationMsg.standard.header.msgh_remote_port = MACH_PORT_NULL;
+  _notificationMsg.standard.header.msgh_local_port  = MACH_PORT_NULL;
+  _notificationMsg.standard.header.msgh_reserved    = 0;
+  _notificationMsg.standard.header.msgh_id          = 0;
 
   HVDBGLOG("Initialized Hyper-V user client");
   return true;
@@ -91,19 +91,27 @@ IOReturn HyperVUserClient::registerNotificationPort(mach_port_t port, UInt32 typ
   }
 
   HVDBGLOG("Registering notification port 0x%p", port);
-  _notificationMsg.header.msgh_remote_port = port;
+  _notificationMsg.standard.header.msgh_remote_port = port;
   return kIOReturnSuccess;
 }
 
 IOReturn HyperVUserClient::notifyClientApplication(HyperVUserClientNotificationType type, void *data, UInt32 dataLength) {
-  if (dataLength > sizeof (_notificationMsg.data)) {
+  if (dataLength > sizeof (_notificationMsg.large.data)) {
     return kIOReturnMessageTooLarge;
   }
 
   HVDBGLOG("Sending notification type %u with %u bytes of data", type, dataLength);
-  _notificationMsg.type = type;
-  memcpy(_notificationMsg.data, data, dataLength);
-  _notificationMsg.dataLength = dataLength;
+  _notificationMsg.standard.type = type;
+  memcpy(_notificationMsg.standard.data, data, dataLength);
+  
+  if (dataLength > sizeof (_notificationMsg.standard.data)) {
+    _notificationMsg.standard.header.msgh_size = sizeof (_notificationMsg.large.data);
+    _notificationMsg.large.dataLength = dataLength;
+  } else {
+    _notificationMsg.standard.header.msgh_size = sizeof (_notificationMsg.standard.data);
+    _notificationMsg.standard.dataLength = dataLength;
+  }
+  
 
-  return mach_msg_send_from_kernel(&_notificationMsg.header, _notificationMsg.header.msgh_size);
+  return mach_msg_send_from_kernel(&_notificationMsg.standard.header, _notificationMsg.standard.header.msgh_size);
 }

--- a/MacHyperVSupport/Controller/HyperVUserClient.cpp
+++ b/MacHyperVSupport/Controller/HyperVUserClient.cpp
@@ -158,13 +158,6 @@ const IOExternalMethodDispatch HyperVUserClient::sMethods[kNumberOfMethods] = {
     0,                                                                 // Num of scalar output values
     0                                                                  // Size of struct output
   },
-  { // kMethodFileCopyMapSharedBuffer
-    (IOExternalMethodAction) &HyperVUserClient::sMethodFileCopyMapSharedBuffer,
-    2,
-    0,
-    1,
-    0
-  },
   { // kMethodFileCopyGetStartCopyData
     (IOExternalMethodAction) &HyperVUserClient::sMethodFileCopyGetStartCopyData,
     0,
@@ -183,23 +176,6 @@ IOReturn HyperVUserClient::sMethodFileCopyReturnGeneric(HyperVUserClient* target
     return kIOReturnNotReady;
   
   fCopy->callPlatformFunction("returnCodeFromUserspace", true, (void *)args->scalarInput, NULL, NULL, NULL);
-  
-  return kIOReturnSuccess;
-}
-
-IOReturn HyperVUserClient::sMethodFileCopyMapSharedBuffer(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args) {
-  IOService *fCopy;
-  IOReturn fCopyRet;
-  
-  target->HVDBGLOG("Userspace called sMethodFileCopyMapSharedBuffer in userclient");
-  
-  fCopy = OSDynamicCast(IOService, target->_drivers->getObject("HyperVFileCopy"));
-  if (!fCopy)
-    return kIOReturnNotReady;
-  
-  // return value, task, user buffer location, user buffer size
-  fCopy->callPlatformFunction("mapSharedBuffer", true, &fCopyRet, target->mTask, (void *) &args->scalarInput[0], (void *) &args->scalarInput[1]);
-  args->scalarOutput[0] = fCopyRet;
   
   return kIOReturnSuccess;
 }

--- a/MacHyperVSupport/Controller/HyperVUserClient.cpp
+++ b/MacHyperVSupport/Controller/HyperVUserClient.cpp
@@ -85,8 +85,7 @@ IOReturn HyperVUserClient::message(UInt32 type, IOService *provider, void *argum
   return super::message(type, provider, argument);
 }
 
-bool HyperVUserClient::initWithTask(task_t owningTask, void *securityToken, UInt32 type, OSDictionary *properties)
-{
+bool HyperVUserClient::initWithTask(task_t owningTask, void *securityToken, UInt32 type, OSDictionary *properties) {
     if (!owningTask)
         return false;
     
@@ -138,7 +137,7 @@ IOReturn HyperVUserClient::notifyClientApplication(HyperVUserClientNotificationT
   return mach_msg_send_from_kernel(&_notificationMsg.header, _notificationMsg.header.msgh_size);
 }
 
-IOReturn HyperVUserClient::externalMethod(uint32_t selector, IOExternalMethodArguments* arguments, IOExternalMethodDispatch* dispatch, OSObject* target, void* reference) {
+IOReturn HyperVUserClient::externalMethod(uint32_t selector, IOExternalMethodArguments *arguments, IOExternalMethodDispatch *dispatch, OSObject *target, void *reference) {
   if (selector >= kNumberOfMethods)
     return kIOReturnUnsupported;
   
@@ -174,7 +173,7 @@ const IOExternalMethodDispatch HyperVUserClient::sMethods[kNumberOfMethods] = {
   }
 };
 
-IOReturn HyperVUserClient::sMethodFileCopyReturnGeneric(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args) {
+IOReturn HyperVUserClient::sMethodFileCopyReturnGeneric(HyperVUserClient *target, void *ref, IOExternalMethodArguments *args) {
   IOService *fCopy;
   target->HVDBGLOG("Userspace called sMethodFileCopyReturnGeneric in userclient");
   
@@ -182,12 +181,12 @@ IOReturn HyperVUserClient::sMethodFileCopyReturnGeneric(HyperVUserClient* target
   if (!fCopy)
     return kIOReturnNotReady;
   
-  fCopy->callPlatformFunction("returnCodeFromUserspace", true, (void *)args->scalarInput, NULL, NULL, NULL);
+  fCopy->callPlatformFunction("returnCodeFromUserspace", true, (void *) args->scalarInput, NULL, NULL, NULL);
   
   return kIOReturnSuccess;
 }
 
-IOReturn HyperVUserClient::sMethodFileCopyGetStartCopyData(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args) {
+IOReturn HyperVUserClient::sMethodFileCopyGetStartCopyData(HyperVUserClient *target, void *ref, IOExternalMethodArguments *args) {
   IOService *fCopy;
   target->HVDBGLOG("Userspace called sMethodFileCopyGetStartCopyData in userclient");
   
@@ -200,9 +199,9 @@ IOReturn HyperVUserClient::sMethodFileCopyGetStartCopyData(HyperVUserClient* tar
   return kIOReturnSuccess;
 }
 
-IOReturn HyperVUserClient::sMethodFileCopyGetDoCopyData(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args) {
+IOReturn HyperVUserClient::sMethodFileCopyGetDoCopyData(HyperVUserClient *target, void *ref, IOExternalMethodArguments *args) {
   IOService *fCopy;
-  IOMemoryMap* map = nullptr;
+  IOMemoryMap *map = nullptr;
   const HyperVUserClientFileCopyDoCopyData *doCopyData;
   size_t doCopyDataSize;
   target->HVDBGLOG("Userspace called sMethodFileCopyGetDoCopyData in userclient");

--- a/MacHyperVSupport/Controller/HyperVUserClient.h
+++ b/MacHyperVSupport/Controller/HyperVUserClient.h
@@ -16,6 +16,7 @@
 typedef enum {
   kMethodFileCopyReturnGeneric,
   kMethodFileCopyGetStartCopyData,
+  kMethodFileCopyGetDoCopyData,
   kNumberOfMethods // Must be last
 } HyperVUserClientMethod;
 

--- a/MacHyperVSupport/Controller/HyperVUserClient.h
+++ b/MacHyperVSupport/Controller/HyperVUserClient.h
@@ -39,10 +39,11 @@ typedef enum : UInt32 {
 } HyperVUserClientFileCopyFlags;
 
 typedef struct __attribute__((packed)) {
+  // fileName & filePath are UTF-16 strings
+  UInt16                         fileName[260];
+  UInt16                         filePath[260];
   HyperVUserClientFileCopyFlags  copyFlags;
   UInt64                         fileSize;
-  UInt8                          fileName[1024];
-  UInt8                          filePath[1024];
 } HyperVUserClientFileCopyStartCopy;
 
 typedef struct __attribute__((packed)) {

--- a/MacHyperVSupport/Controller/HyperVUserClient.h
+++ b/MacHyperVSupport/Controller/HyperVUserClient.h
@@ -23,6 +23,7 @@ typedef enum {
 typedef enum : UInt32 {
   kHyperVUserClientStatusSuccess        = 0x00000000,
   kHyperVUserClientStatusFailure        = 0x80004005,
+  kHyperVUserClientStatusTimedOut       = 0x800705B4,
   kHyperVUserClientStatusInvalidArg     = 0x80070057,
   kHyperVUserClientStatusAlreadyExists  = 0x80070050,
   kHyperVUserClientStatusDiskFull       = 0x80070070

--- a/MacHyperVSupport/Controller/HyperVUserClient.h
+++ b/MacHyperVSupport/Controller/HyperVUserClient.h
@@ -15,7 +15,6 @@
 
 typedef enum {
   kMethodFileCopyReturnGeneric,
-  kMethodFileCopyMapSharedBuffer,
   kMethodFileCopyGetStartCopyData,
   kNumberOfMethods // Must be last
 } HyperVUserClientMethod;

--- a/MacHyperVSupport/Controller/HyperVUserClient.h
+++ b/MacHyperVSupport/Controller/HyperVUserClient.h
@@ -39,11 +39,10 @@ typedef enum : UInt32 {
 } HyperVUserClientFileCopyFlags;
 
 typedef struct __attribute__((packed)) {
-  // fileName & filePath are UTF-16 strings
-  UInt16                         fileName[260];
-  UInt16                         filePath[260];
   HyperVUserClientFileCopyFlags  copyFlags;
   UInt64                         fileSize;
+  UInt8                          fileName[1024];
+  UInt8                          filePath[1024];
 } HyperVUserClientFileCopyStartCopy;
 
 typedef struct __attribute__((packed)) {

--- a/MacHyperVSupport/Controller/HyperVUserClient.h
+++ b/MacHyperVSupport/Controller/HyperVUserClient.h
@@ -11,7 +11,8 @@
 #include <libkern/OSTypes.h>
 #include <mach/message.h>
 
-#define kHyperVUserClientNotificationMessageDataLength 64
+#define kHyperVUserClientNotificationMessageDataStandardLength 64
+#define kHyperVUserClientNotificationMessageDataLargeLength (kHyperVUserClientNotificationMessageDataStandardLength + (6 * 1024))
 
 typedef enum : UInt32 {
   kHyperVUserClientNotificationTypePerformShutdown = 0x66697368,
@@ -24,15 +25,28 @@ typedef struct {
   UInt32 microseconds;
 } HyperVUserClientTimeData;
 
-typedef struct {
-  mach_msg_header_t                header;
-  HyperVUserClientNotificationType type;
-  UInt8                            data[kHyperVUserClientNotificationMessageDataLength];
-  UInt32                           dataLength;
 
+typedef union {
+  struct {
+    mach_msg_header_t                header;
+    HyperVUserClientNotificationType type;
+    UInt8                            data[kHyperVUserClientNotificationMessageDataStandardLength];
+    UInt32                           dataLength;
+    
 #ifndef KERNEL
-  mach_msg_trailer_t               trailer;
+    mach_msg_trailer_t               trailer;
 #endif
+  } standard;
+  struct {
+    mach_msg_header_t                header;
+    HyperVUserClientNotificationType type;
+    UInt8                            data[kHyperVUserClientNotificationMessageDataLargeLength];
+    UInt32                           dataLength;
+    
+#ifndef KERNEL
+    mach_msg_trailer_t               trailer;
+#endif
+  } large;
 } HyperVUserClientNotificationMessage;
 
 #endif

--- a/MacHyperVSupport/Controller/HyperVUserClient.h
+++ b/MacHyperVSupport/Controller/HyperVUserClient.h
@@ -11,8 +11,7 @@
 #include <libkern/OSTypes.h>
 #include <mach/message.h>
 
-#define kHyperVUserClientNotificationMessageDataStandardLength 64
-#define kHyperVUserClientNotificationMessageDataLargeLength (kHyperVUserClientNotificationMessageDataStandardLength + (6 * 1024))
+#define kHyperVUserClientNotificationMessageDataLength 64
 
 typedef enum {
     kMethodReturnFileCopy,
@@ -75,27 +74,15 @@ typedef struct __attribute__((packed)) {
   } operationData;
 } HyperVUserClientFileCopy;
 
-typedef union {
-  struct {
-    mach_msg_header_t                header;
-    HyperVUserClientNotificationType type;
-    UInt8                            data[kHyperVUserClientNotificationMessageDataStandardLength];
-    UInt32                           dataLength;
-    
+typedef struct {
+  mach_msg_header_t                header;
+  HyperVUserClientNotificationType type;
+  UInt8                            data[kHyperVUserClientNotificationMessageDataLength];
+  UInt32                           dataLength;
+  
 #ifndef KERNEL
-    mach_msg_trailer_t               trailer;
+  mach_msg_trailer_t               trailer;
 #endif
-  } standard;
-  struct {
-    mach_msg_header_t                header;
-    HyperVUserClientNotificationType type;
-    UInt8                            data[kHyperVUserClientNotificationMessageDataLargeLength];
-    UInt32                           dataLength;
-    
-#ifndef KERNEL
-    mach_msg_trailer_t               trailer;
-#endif
-  } large;
 } HyperVUserClientNotificationMessage;
 
 #endif

--- a/MacHyperVSupport/Controller/HyperVUserClient.h
+++ b/MacHyperVSupport/Controller/HyperVUserClient.h
@@ -17,7 +17,8 @@
 typedef enum : UInt32 {
   kHyperVUserClientNotificationTypePerformShutdown = 0x66697368,
   kHyperVUserClientNotificationTypePerformRestart,
-  kHyperVUserClientNotificationTypeTimeSync
+  kHyperVUserClientNotificationTypeTimeSync,
+  kHyperVUserClientNotificationTypeFileCopy
 } HyperVUserClientNotificationType;
 
 typedef struct {
@@ -25,6 +26,39 @@ typedef struct {
   UInt32 microseconds;
 } HyperVUserClientTimeData;
 
+typedef enum : UInt32 {
+  kHyperVUserClientFileCopyOperationStartFileCopy     = 0,
+  kHyperVUserClientFileCopyOperationWriteToFile       = 1,
+  kHyperVUserClientFileCopyOperationCompleteFileCopy  = 2,
+  kHyperVUserClientFileCopyOperationCancelFileCopy    = 3
+} HyperVUserClientFileCopyOperation;
+
+typedef enum : UInt32 {
+  kHyperVUserClientFileCopyFlagsOverwrite   = 1,
+  kHyperVUserClientFileCopyFlagsCreatePath  = 2
+} HyperVUserClientFileCopyFlags;
+
+typedef struct __attribute__((packed)) {
+  HyperVUserClientFileCopyFlags  copyFlags;
+  UInt64                         fileSize;
+  UInt8                          fileName[1024];
+  UInt8                          filePath[1024];
+} HyperVUserClientFileCopyStartCopy;
+
+typedef struct __attribute__((packed)) {
+  UInt32  reserved;
+  UInt64  offset;
+  UInt32  size;
+  UInt8   data[(6 * 1024)];
+} HyperVUserClientFileCopyDoCopy;
+
+typedef struct __attribute__((packed)) {
+  HyperVUserClientFileCopyOperation    operation;
+  union {
+    HyperVUserClientFileCopyStartCopy  startCopy;
+    HyperVUserClientFileCopyDoCopy     doCopy;
+  } operationData;
+} HyperVUserClientFileCopy;
 
 typedef union {
   struct {

--- a/MacHyperVSupport/Controller/HyperVUserClient.h
+++ b/MacHyperVSupport/Controller/HyperVUserClient.h
@@ -14,6 +14,20 @@
 #define kHyperVUserClientNotificationMessageDataStandardLength 64
 #define kHyperVUserClientNotificationMessageDataLargeLength (kHyperVUserClientNotificationMessageDataStandardLength + (6 * 1024))
 
+typedef enum {
+    kMethodReturnFileCopy,
+    
+    kNumberOfMethods // Must be last
+} HyperVUserClientMethod;
+
+typedef enum : UInt32 {
+  kHyperVUserClientStatusSuccess        = 0x00000000,
+  kHyperVUserClientStatusFailure        = 0x80004005,
+  kHyperVUserClientStatusInvalidArg     = 0x80070057,
+  kHyperVUserClientStatusAlreadyExists  = 0x80070050,
+  kHyperVUserClientStatusDiskFull       = 0x80070070
+} HyperVUserClientStatusCode;
+
 typedef enum : UInt32 {
   kHyperVUserClientNotificationTypePerformShutdown = 0x66697368,
   kHyperVUserClientNotificationTypePerformRestart,

--- a/MacHyperVSupport/Controller/HyperVUserClient.h
+++ b/MacHyperVSupport/Controller/HyperVUserClient.h
@@ -14,9 +14,10 @@
 #define kHyperVUserClientNotificationMessageDataLength 64
 
 typedef enum {
-    kMethodReturnFileCopy,
-    
-    kNumberOfMethods // Must be last
+  kMethodFileCopyReturnGeneric,
+  kMethodFileCopyMapSharedBuffer,
+  kMethodFileCopyGetStartCopyData,
+  kNumberOfMethods // Must be last
 } HyperVUserClientMethod;
 
 typedef enum : UInt32 {
@@ -44,7 +45,8 @@ typedef enum : UInt32 {
   kHyperVUserClientFileCopyOperationStartFileCopy     = 0,
   kHyperVUserClientFileCopyOperationWriteToFile       = 1,
   kHyperVUserClientFileCopyOperationCompleteFileCopy  = 2,
-  kHyperVUserClientFileCopyOperationCancelFileCopy    = 3
+  kHyperVUserClientFileCopyOperationCancelFileCopy    = 3,
+  kHyperVUserClientFileCopySetup                      = 4
 } HyperVUserClientFileCopyOperation;
 
 typedef enum : UInt32 {
@@ -53,26 +55,32 @@ typedef enum : UInt32 {
 } HyperVUserClientFileCopyFlags;
 
 typedef struct __attribute__((packed)) {
-  HyperVUserClientFileCopyFlags  copyFlags;
-  UInt64                         fileSize;
-  UInt8                          fileName[1024];
-  UInt8                          filePath[1024];
-} HyperVUserClientFileCopyStartCopy;
+  UInt8  fileName[PATH_MAX];
+  UInt8  filePath[PATH_MAX];
+} HyperVUserClientFileCopyStartCopyData;
 
+#define kHyperVFileCopyFragmentSize (6 * 1024)
 typedef struct __attribute__((packed)) {
-  UInt32  reserved;
+  UInt8   data[kHyperVFileCopyFragmentSize];
+} HyperVUserClientFileCopyDoCopyData;
+
+typedef struct {
+  UInt64                         fileSize;
+  HyperVUserClientFileCopyFlags  copyFlags;
+} HyperVUserClientFileCopyStartCopyParam;
+
+typedef struct {
   UInt64  offset;
   UInt32  size;
-  UInt8   data[(6 * 1024)];
-} HyperVUserClientFileCopyDoCopy;
+} HyperVUserClientFileCopyDoCopyParam;
 
-typedef struct __attribute__((packed)) {
-  HyperVUserClientFileCopyOperation    operation;
+typedef struct {
+  HyperVUserClientFileCopyOperation  operation;
   union {
-    HyperVUserClientFileCopyStartCopy  startCopy;
-    HyperVUserClientFileCopyDoCopy     doCopy;
-  } operationData;
-} HyperVUserClientFileCopy;
+    HyperVUserClientFileCopyStartCopyParam startCopy;
+    HyperVUserClientFileCopyDoCopyParam doCopy;
+  };
+} HyperVUserClientFileCopyMessage;
 
 typedef struct {
   mach_msg_header_t                header;

--- a/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
+++ b/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
@@ -56,6 +56,7 @@ protected:
   //
   static IOReturn sMethodFileCopyReturnGeneric(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
   static IOReturn sMethodFileCopyGetStartCopyData(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
+  static IOReturn sMethodFileCopyGetDoCopyData(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
 };
 
 #endif

--- a/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
+++ b/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
@@ -20,8 +20,11 @@ class HyperVUserClient : public IOUserClient {
   typedef IOUserClient super;
 
 private:
-  HyperVController                    *_hvController   = nullptr;
-  HyperVUserClientNotificationMessage _notificationMsg = { };
+  HyperVController                      *_hvController   = nullptr;
+  HyperVUserClientNotificationMessage    _notificationMsg = { };
+  static const IOExternalMethodDispatch  sMethods[kNumberOfMethods];
+  static UInt64                          callbacks[kNumberOfMethods];
+  task_t                                 mTask;
 
 public:
   //
@@ -34,13 +37,20 @@ public:
   //
   // IOUserClient overrides.
   //
+  virtual bool initWithTask(task_t owningTask, void* securityToken,
+                                UInt32 type, OSDictionary* properties) APPLE_KEXT_OVERRIDE;
   IOReturn clientClose() APPLE_KEXT_OVERRIDE;
   IOReturn registerNotificationPort(mach_port_t port, UInt32 type, UInt32 refCon) APPLE_KEXT_OVERRIDE;
+  IOReturn externalMethod(uint32_t selector, IOExternalMethodArguments* arguments, IOExternalMethodDispatch* dispatch, OSObject* target, void* reference) APPLE_KEXT_OVERRIDE;
 
   //
   // Other functions.
   //
   IOReturn notifyClientApplication(HyperVUserClientNotificationType type, void *data, UInt32 dataLength);
+  static void registerDriverCallback(HyperVUserClientMethod index, UInt64 callback);
+  
+protected:
+  static IOReturn sMethodReturnFileCopy(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
 };
 
 #endif

--- a/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
+++ b/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
@@ -23,8 +23,8 @@ private:
   HyperVController                      *_hvController   = nullptr;
   HyperVUserClientNotificationMessage    _notificationMsg = { };
   static const IOExternalMethodDispatch  sMethods[kNumberOfMethods];
-  static UInt64                          callbacks[kNumberOfMethods];
   task_t                                 mTask;
+  OSDictionary                          *_drivers;
 
 public:
   //
@@ -47,7 +47,8 @@ public:
   // Other functions.
   //
   IOReturn notifyClientApplication(HyperVUserClientNotificationType type, void *data, UInt32 dataLength);
-  static void registerDriverCallback(HyperVUserClientMethod index, UInt64 callback);
+  bool registerDriver(IOService *driver);
+  void deregisterDriver(IOService *driver);
   
 protected:
   static IOReturn sMethodReturnFileCopy(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);

--- a/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
+++ b/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
@@ -55,7 +55,6 @@ protected:
   // File Copy functions.
   //
   static IOReturn sMethodFileCopyReturnGeneric(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
-  static IOReturn sMethodFileCopyMapSharedBuffer(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
   static IOReturn sMethodFileCopyGetStartCopyData(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
 };
 

--- a/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
+++ b/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
@@ -51,7 +51,12 @@ public:
   void deregisterDriver(IOService *driver);
   
 protected:
-  static IOReturn sMethodReturnFileCopy(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
+  //
+  // File Copy functions.
+  //
+  static IOReturn sMethodFileCopyReturnGeneric(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
+  static IOReturn sMethodFileCopyMapSharedBuffer(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
+  static IOReturn sMethodFileCopyGetStartCopyData(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
 };
 
 #endif

--- a/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
+++ b/MacHyperVSupport/Controller/HyperVUserClientInternal.hpp
@@ -37,11 +37,11 @@ public:
   //
   // IOUserClient overrides.
   //
-  virtual bool initWithTask(task_t owningTask, void* securityToken,
-                                UInt32 type, OSDictionary* properties) APPLE_KEXT_OVERRIDE;
+  virtual bool initWithTask(task_t owningTask, void *securityToken,
+                                UInt32 type, OSDictionary *properties) APPLE_KEXT_OVERRIDE;
   IOReturn clientClose() APPLE_KEXT_OVERRIDE;
   IOReturn registerNotificationPort(mach_port_t port, UInt32 type, UInt32 refCon) APPLE_KEXT_OVERRIDE;
-  IOReturn externalMethod(uint32_t selector, IOExternalMethodArguments* arguments, IOExternalMethodDispatch* dispatch, OSObject* target, void* reference) APPLE_KEXT_OVERRIDE;
+  IOReturn externalMethod(uint32_t selector, IOExternalMethodArguments *arguments, IOExternalMethodDispatch *dispatch, OSObject *target, void *reference) APPLE_KEXT_OVERRIDE;
 
   //
   // Other functions.
@@ -54,9 +54,9 @@ protected:
   //
   // File Copy functions.
   //
-  static IOReturn sMethodFileCopyReturnGeneric(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
-  static IOReturn sMethodFileCopyGetStartCopyData(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
-  static IOReturn sMethodFileCopyGetDoCopyData(HyperVUserClient* target, void* ref, IOExternalMethodArguments* args);
+  static IOReturn sMethodFileCopyReturnGeneric(HyperVUserClient *target, void *ref, IOExternalMethodArguments *args);
+  static IOReturn sMethodFileCopyGetStartCopyData(HyperVUserClient *target, void *ref, IOExternalMethodArguments *args);
+  static IOReturn sMethodFileCopyGetDoCopyData(HyperVUserClient *target, void *ref, IOExternalMethodArguments *args);
 };
 
 #endif

--- a/MacHyperVSupport/Info.plist
+++ b/MacHyperVSupport/Info.plist
@@ -211,6 +211,17 @@
 			<key>IOProviderClass</key>
 			<string>HyperVVMBusDevice</string>
 		</dict>
+		<key>HyperVFileCopy</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>HVType</key>
+			<string>34d14be3-dee4-41c8-9ae7-6b174977c192</string>
+			<key>IOClass</key>
+			<string>HyperVFileCopy</string>
+			<key>IOProviderClass</key>
+			<string>HyperVVMBusDevice</string>
+		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2021-2022 Goldfish64. All rights reserved.</string>

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
@@ -26,19 +26,31 @@ bool HyperVFileCopy::start(IOService *provider) {
 
   HVCheckDebugArgs();
   setICDebug(debugEnabled);
+  
+  _hvDevice->getHvController()->registerUserClientDriverCallback(kMethodReturnFileCopy, (mach_vm_address_t)responseFromUserspace);
+  lock = IOLockAlloc();
+  if (lock == NULL) {
+    HVSYSLOG("Failed to allocate lock for userspace transactions");
+    return false;
+  }
 
   HVDBGLOG("Initializing Hyper-V File Copy");
+  registerService();
   return true;
 }
 
 void HyperVFileCopy::stop(IOService *provider) {
   HVDBGLOG("Stopping Hyper-V File Copy");
+  _hvDevice->getHvController()->registerUserClientDriverCallback(kMethodReturnFileCopy, (mach_vm_address_t)nullptr);
+  IOLockFree(lock);
   super::stop(provider);
 }
 
 void HyperVFileCopy::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength) {
   VMBusICMessageFileCopy *fileCopyMsg = (VMBusICMessageFileCopy*) pktData;
   HyperVUserClientFileCopy userClientMsg;
+  UInt8 unicodeNul[3] = { 0xE2, 0x90, 0x80 };
+  void *unicodeNulLoc;
   size_t nlen;
   size_t plen;
 
@@ -57,6 +69,7 @@ void HyperVFileCopy::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeader
       if (!_hvDevice->getHvController()->checkUserClient()) {
         HVDBGLOG("Userspace is not ready yet");
         fileCopyMsg->header.status = kHyperVStatusFail;
+        break;
       }
       switch (fileCopyMsg->fcopyHeader.operation) {
         case kVMBusICFileCopyOperationStartFileCopy:
@@ -66,17 +79,34 @@ void HyperVFileCopy::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeader
           memset(&userClientMsg, 0, sizeof (userClientMsg));
           if (fileCopyMsg->fcopyHeader.operation == kVMBusICFileCopyOperationStartFileCopy) {
             memset(&userClientMsg.operationData.startCopy.fileName, 0, PATH_MAX);
-            utf8_encodestr(fileCopyMsg->startCopy.fileName, kHyperVFileCopyMaxPath, (UInt8*)&userClientMsg.operationData.startCopy.fileName, &nlen, PATH_MAX, 0, 0);
+            utf8_encodestr(fileCopyMsg->startCopy.fileName, kHyperVFileCopyMaxPath * 2, (UInt8*)&userClientMsg.operationData.startCopy.fileName, &nlen, PATH_MAX, '_', UTF_LITTLE_ENDIAN);
+            unicodeNulLoc = lilu_os_memmem((UInt8*)&userClientMsg.operationData.startCopy.fileName, PATH_MAX, &unicodeNul, sizeof (unicodeNul));
+            if (!unicodeNulLoc) {
+              fileCopyMsg->header.status = kHyperVStatusFail;
+              break;
+            }
+            *(char *)unicodeNulLoc = 0x00;
+            
             memset(&userClientMsg.operationData.startCopy.filePath, 0, PATH_MAX);
-            utf8_encodestr(fileCopyMsg->startCopy.filePath, kHyperVFileCopyMaxPath, (UInt8*)&userClientMsg.operationData.startCopy.filePath, &plen, PATH_MAX, 0, 0);
+            utf8_encodestr(fileCopyMsg->startCopy.filePath, kHyperVFileCopyMaxPath * 2, (UInt8*)&userClientMsg.operationData.startCopy.filePath, &plen, PATH_MAX, '/', UTF_LITTLE_ENDIAN);
+            unicodeNulLoc = lilu_os_memmem((UInt8*)&userClientMsg.operationData.startCopy.filePath, PATH_MAX, &unicodeNul, sizeof (unicodeNul));
+            if (!unicodeNulLoc) {
+              fileCopyMsg->header.status = kHyperVStatusFail;
+              break;
+            }
+            *(char *)unicodeNulLoc = 0x00;
+            
             userClientMsg.operationData.startCopy.fileSize = fileCopyMsg->startCopy.fileSize;
             userClientMsg.operationData.startCopy.copyFlags = (HyperVUserClientFileCopyFlags)fileCopyMsg->startCopy.copyFlags;
+            
             HVSYSLOG("File copy attempted for file %s at path %s", &userClientMsg.operationData.startCopy.fileName, &userClientMsg.operationData.startCopy.filePath);
           } else {
             memcpy(&userClientMsg.operationData, fileCopyMsg + sizeof (VMBusICMessageFileCopyHeader), pktDataLength - sizeof (VMBusICMessageFileCopyHeader));
           }
           userClientMsg.operation = (HyperVUserClientFileCopyOperation)fileCopyMsg->fcopyHeader.operation;
           _hvDevice->getHvController()->notifyUserClient(kHyperVUserClientNotificationTypeFileCopy, &userClientMsg, sizeof (userClientMsg));
+          sleepForUserspace();
+          fileCopyMsg->header.status = status;
           
           break;
         default:
@@ -97,4 +127,45 @@ void HyperVFileCopy::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeader
   //
   fileCopyMsg->header.flags = kVMBusICFlagTransaction | kVMBusICFlagResponse;
   _hvDevice->writeInbandPacket(fileCopyMsg, pktDataLength, false);
+}
+
+void HyperVFileCopy::sleepForUserspace() {
+  HVDBGLOG("Sleeping until response from userspace", status);
+  isSleeping = true;
+  IOLockLock(lock);
+  while (isSleeping) {
+    IOLockSleep(lock, &isSleeping, THREAD_INTERRUPTIBLE);
+  }
+  IOLockUnlock(lock);
+}
+
+void HyperVFileCopy::wakeForUserspace() {
+  HVDBGLOG("Waking after response from userspace", status);
+  IOLockLock(lock);
+  isSleeping = false;
+  IOLockWakeup(lock, &isSleeping, false);
+  IOLockUnlock(lock);
+}
+
+void HyperVFileCopy::responseFromUserspace(int *status) {
+  OSDictionary *fcopyMatching = IOService::serviceMatching("HyperVFileCopy");
+  if (fcopyMatching == NULL) {
+    return;
+  }
+  
+  OSIterator *fcopyIterator = IOService::getMatchingServices(fcopyMatching);
+  if (fcopyIterator == NULL) {
+    return;
+  }
+  
+  fcopyIterator->reset();
+  HyperVFileCopy *fcopyInstance = OSDynamicCast(HyperVFileCopy, fcopyIterator->getNextObject());
+  fcopyIterator->release();
+  
+  if (fcopyInstance == NULL) {
+    return;
+  }
+  fcopyInstance->HVDBGLOG("Got response from userspace: 0x%x", status);
+  fcopyInstance->status = *status;
+  fcopyInstance->wakeForUserspace();
 }

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
@@ -64,19 +64,9 @@ void HyperVFileCopy::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeader
         case kVMBusICFileCopyOperationCompleteFileCopy:
         case kVMBusICFileCopyOperationCancelFileCopy:
           memset(&userClientMsg, 0, sizeof (userClientMsg));
-          if (fileCopyMsg->fcopyHeader.operation == kVMBusICFileCopyOperationStartFileCopy) {
-            memset(&userClientMsg.operationData.startCopy.fileName, 0, PATH_MAX);
-            utf8_encodestr(fileCopyMsg->startCopy.fileName, kHyperVFileCopyMaxPath, (UInt8*)&userClientMsg.operationData.startCopy.fileName, &nlen, PATH_MAX, 0, 0);
-            memset(&userClientMsg.operationData.startCopy.filePath, 0, PATH_MAX);
-            utf8_encodestr(fileCopyMsg->startCopy.filePath, kHyperVFileCopyMaxPath, (UInt8*)&userClientMsg.operationData.startCopy.filePath, &plen, PATH_MAX, 0, 0);
-            userClientMsg.operationData.startCopy.fileSize = fileCopyMsg->startCopy.fileSize;
-            userClientMsg.operationData.startCopy.copyFlags = (HyperVUserClientFileCopyFlags)fileCopyMsg->startCopy.copyFlags;
-            HVSYSLOG("File copy attempted for file %s at path %s", &userClientMsg.operationData.startCopy.fileName, &userClientMsg.operationData.startCopy.filePath);
-          } else {
-            memcpy(&userClientMsg.operationData, fileCopyMsg + sizeof (VMBusICMessageFileCopyHeader), pktDataLength - sizeof (VMBusICMessageFileCopyHeader));
-          }
+          memcpy(&userClientMsg.operationData, fileCopyMsg + sizeof (VMBusICMessageFileCopyHeader), pktDataLength - sizeof (VMBusICMessageFileCopyHeader));
           userClientMsg.operation = (HyperVUserClientFileCopyOperation)fileCopyMsg->fcopyHeader.operation;
-          _hvDevice->getHvController()->notifyUserClient(kHyperVUserClientNotificationTypeFileCopy, &userClientMsg, sizeof (userClientMsg));
+          _hvDevice->getHvController()->notifyUserClient(kHyperVUserClientNotificationTypeFileCopy, &userClientMsg, sizeof (HyperVUserClientFileCopy));
           
           break;
         default:

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
@@ -1,0 +1,83 @@
+//
+//  HyperVFileCopy.cpp
+//  Hyper-V file copy driver
+//
+//  Copyright © 2022 flagers. All rights reserved.
+//
+
+#include "HyperVFileCopy.hpp"
+
+OSDefineMetaClassAndStructors(HyperVFileCopy, super);
+
+static const VMBusICVersion fcopyVersions[] = {
+  kHyperVFileCopyVersionV1
+};
+
+bool HyperVFileCopy::start(IOService *provider) {
+  if (HVCheckOffArg()) {
+    HVSYSLOG("Disabling Hyper-V File Copy due to boot arg");
+    return false;
+  }
+
+  if (!super::start(provider)) {
+    HVSYSLOG("super::start() returned false");
+    return false;
+  }
+
+  HVCheckDebugArgs();
+  setICDebug(debugEnabled);
+
+  HVDBGLOG("Initializing Hyper-V File Copy");
+  return true;
+}
+
+void HyperVFileCopy::stop(IOService *provider) {
+  HVDBGLOG("Stopping Hyper-V File Copy");
+  super::stop(provider);
+}
+
+void HyperVFileCopy::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength) {
+  VMBusICMessageFileCopy *fileCopyMsg = (VMBusICMessageFileCopy*) pktData;
+
+  switch (fileCopyMsg->header.type) {
+    case kVMBusICMessageTypeNegotiate:
+      //
+      // Determine supported protocol version and communicate back to Hyper-V.
+      //
+      if (!processNegotiationResponse(&fileCopyMsg->negotiate, fcopyVersions, arrsize(fcopyVersions))) {
+        HVSYSLOG("Failed to determine a supported Hyper-V File Copy version");
+        fileCopyMsg->header.status = kHyperVStatusFail;
+      }
+      break;
+
+    case kVMBusICMessageTypeFileCopy:
+      if (!_hvDevice->getHvController()->checkUserClient()) {
+        HVDBGLOG("Userspace is not ready yet");
+        fileCopyMsg->header.status = kHyperVStatusFail;
+      }
+      switch (fileCopyMsg->fcopyHeader.operation) {
+        case kVMBusICFileCopyOperationStartFileCopy:
+          UInt8 pbuf[PATH_MAX];
+          size_t plen;
+          utf8_encodestr(fileCopyMsg->startCopy.fileName, kHyperVFileCopyMaxPath, (UInt8*)&pbuf, &plen, PATH_MAX, 0, 0);
+          HVSYSLOG("File copy attempted for file: %s", &pbuf);
+          break;
+        default:
+          HVDBGLOG("Unknown file copy operation type %u", fileCopyMsg->fcopyHeader.operation);
+          fileCopyMsg->header.status = kHyperVStatusFail;
+          break;
+      }
+      break;
+
+    default:
+      HVDBGLOG("Unknown file copy message type %u", fileCopyMsg->header.type);
+      fileCopyMsg->header.status = kHyperVStatusFail;
+      break;
+  }
+
+  //
+  // Send response back to Hyper-V. The packet size will always be the same as the original inbound one.
+  //
+  fileCopyMsg->header.flags = kVMBusICFlagTransaction | kVMBusICFlagResponse;
+  _hvDevice->writeInbandPacket(fileCopyMsg, pktDataLength, false);
+}

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
@@ -64,9 +64,19 @@ void HyperVFileCopy::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeader
         case kVMBusICFileCopyOperationCompleteFileCopy:
         case kVMBusICFileCopyOperationCancelFileCopy:
           memset(&userClientMsg, 0, sizeof (userClientMsg));
-          memcpy(&userClientMsg.operationData, fileCopyMsg + sizeof (VMBusICMessageFileCopyHeader), pktDataLength - sizeof (VMBusICMessageFileCopyHeader));
+          if (fileCopyMsg->fcopyHeader.operation == kVMBusICFileCopyOperationStartFileCopy) {
+            memset(&userClientMsg.operationData.startCopy.fileName, 0, PATH_MAX);
+            utf8_encodestr(fileCopyMsg->startCopy.fileName, kHyperVFileCopyMaxPath, (UInt8*)&userClientMsg.operationData.startCopy.fileName, &nlen, PATH_MAX, 0, 0);
+            memset(&userClientMsg.operationData.startCopy.filePath, 0, PATH_MAX);
+            utf8_encodestr(fileCopyMsg->startCopy.filePath, kHyperVFileCopyMaxPath, (UInt8*)&userClientMsg.operationData.startCopy.filePath, &plen, PATH_MAX, 0, 0);
+            userClientMsg.operationData.startCopy.fileSize = fileCopyMsg->startCopy.fileSize;
+            userClientMsg.operationData.startCopy.copyFlags = (HyperVUserClientFileCopyFlags)fileCopyMsg->startCopy.copyFlags;
+            HVSYSLOG("File copy attempted for file %s at path %s", &userClientMsg.operationData.startCopy.fileName, &userClientMsg.operationData.startCopy.filePath);
+          } else {
+            memcpy(&userClientMsg.operationData, fileCopyMsg + sizeof (VMBusICMessageFileCopyHeader), pktDataLength - sizeof (VMBusICMessageFileCopyHeader));
+          }
           userClientMsg.operation = (HyperVUserClientFileCopyOperation)fileCopyMsg->fcopyHeader.operation;
-          _hvDevice->getHvController()->notifyUserClient(kHyperVUserClientNotificationTypeFileCopy, &userClientMsg, sizeof (HyperVUserClientFileCopy));
+          _hvDevice->getHvController()->notifyUserClient(kHyperVUserClientNotificationTypeFileCopy, &userClientMsg, sizeof (userClientMsg));
           
           break;
         default:

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
@@ -58,90 +58,70 @@ void HyperVFileCopy::stop(IOService *provider) {
 }
 
 void HyperVFileCopy::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength) {
-  VMBusICMessageFileCopy *fileCopyMsg = (VMBusICMessageFileCopy*) pktData;
-  HyperVUserClientFileCopy userClientMsg;
-  UInt8 unicodeNul[3] = { 0xE2, 0x90, 0x80 };
-  void *unicodeNulLoc;
-  size_t nlen;
-  size_t plen;
+  _fileCopyPkt = (VMBusICMessageFileCopy*) pktData;
+  HyperVUserClientFileCopyMessage fileCopyMsg;
 
-  switch (fileCopyMsg->header.type) {
+  switch (_fileCopyPkt->header.type) {
     case kVMBusICMessageTypeNegotiate:
       //
       // Determine supported protocol version and communicate back to Hyper-V.
       //
-      if (!processNegotiationResponse(&fileCopyMsg->negotiate, fcopyVersions, arrsize(fcopyVersions))) {
+      if (!processNegotiationResponse(&_fileCopyPkt->negotiate, fcopyVersions, arrsize(fcopyVersions))) {
         HVSYSLOG("Failed to determine a supported Hyper-V File Copy version");
-        fileCopyMsg->header.status = kHyperVStatusFail;
+        _fileCopyPkt->header.status = kHyperVStatusFail;
       }
       break;
 
     case kVMBusICMessageTypeFileCopy:
-      if (!_hvDevice->getHvController()->checkUserClient() || !isRegistered) {
+      if (!_hvDevice->getHvController()->checkUserClient() || !isRegistered || !userClientChunkBuffer) {
         HVDBGLOG("Userspace or user client is not ready yet");
-        fileCopyMsg->header.status = kHyperVStatusFail;
+        _fileCopyPkt->header.status = kHyperVStatusFail;
         break;
       }
-      switch (fileCopyMsg->fcopyHeader.operation) {
-        case kVMBusICFileCopyOperationStartFileCopy:
-        case kVMBusICFileCopyOperationWriteToFile:
-        case kVMBusICFileCopyOperationCompleteFileCopy:
-        case kVMBusICFileCopyOperationCancelFileCopy:
-          memset(&userClientMsg, 0, sizeof (userClientMsg));
-          if (fileCopyMsg->fcopyHeader.operation == kVMBusICFileCopyOperationStartFileCopy) {
-            memset(&userClientMsg.operationData.startCopy.fileName, 0, PATH_MAX);
-            utf8_encodestr(fileCopyMsg->startCopy.fileName, kHyperVFileCopyMaxPath * 2, (UInt8*)&userClientMsg.operationData.startCopy.fileName, &nlen, PATH_MAX, '_', UTF_LITTLE_ENDIAN);
-            unicodeNulLoc = lilu_os_memmem((UInt8*)&userClientMsg.operationData.startCopy.fileName, PATH_MAX, &unicodeNul, sizeof (unicodeNul));
-            if (!unicodeNulLoc) {
-              fileCopyMsg->header.status = kHyperVStatusFail;
-              break;
-            }
-            *(char *)unicodeNulLoc = 0x00;
+      HVDBGLOG("File copy operation type %u attempted", _fileCopyPkt->fcopyHeader.operation);
+      switch (_fileCopyPkt->fcopyHeader.operation) {
+        case kHyperVUserClientFileCopyOperationStartFileCopy:
+        case kHyperVUserClientFileCopyOperationWriteToFile:
+          fileCopyMsg.operation = _fileCopyPkt->fcopyHeader.operation;
+          if (_fileCopyPkt->fcopyHeader.operation == kHyperVUserClientFileCopyOperationStartFileCopy) {
+            fileCopyMsg.startCopy.fileSize = _fileCopyPkt->startCopy.fileSize;
+            fileCopyMsg.startCopy.copyFlags = _fileCopyPkt->startCopy.copyFlags;
+            // Ask userspace to start a copy transaction and wait for it to provide a buffer.
+            _hvDevice->getHvController()->notifyUserClient(kHyperVUserClientNotificationTypeFileCopy, &fileCopyMsg, sizeof (fileCopyMsg));
+            sleepForUserspace();
+            _fileCopyPkt->header.status = this->status;
             
-            memset(&userClientMsg.operationData.startCopy.filePath, 0, PATH_MAX);
-            utf8_encodestr(fileCopyMsg->startCopy.filePath, kHyperVFileCopyMaxPath * 2, (UInt8*)&userClientMsg.operationData.startCopy.filePath, &plen, PATH_MAX, '/', UTF_LITTLE_ENDIAN);
-            unicodeNulLoc = lilu_os_memmem((UInt8*)&userClientMsg.operationData.startCopy.filePath, PATH_MAX, &unicodeNul, sizeof (unicodeNul));
-            if (!unicodeNulLoc) {
-              fileCopyMsg->header.status = kHyperVStatusFail;
-              break;
-            }
-            *(char *)unicodeNulLoc = 0x00;
-            
-            userClientMsg.operationData.startCopy.fileSize = fileCopyMsg->startCopy.fileSize;
-            userClientMsg.operationData.startCopy.copyFlags = (HyperVUserClientFileCopyFlags)fileCopyMsg->startCopy.copyFlags;
-            
-            HVSYSLOG("File copy attempted for file %s at path %s", &userClientMsg.operationData.startCopy.fileName, &userClientMsg.operationData.startCopy.filePath);
-          } else {
-            memcpy(&userClientMsg.operationData, fileCopyMsg + sizeof (VMBusICMessageFileCopyHeader), pktDataLength - sizeof (VMBusICMessageFileCopyHeader));
+          } else if (_fileCopyPkt->fcopyHeader.operation == kHyperVUserClientFileCopyOperationWriteToFile) {
+            fileCopyMsg.doCopy.offset = _fileCopyPkt->doCopy.offset;
+            fileCopyMsg.doCopy.size = _fileCopyPkt->doCopy.size;
+            _hvDevice->getHvController()->notifyUserClient(kHyperVUserClientNotificationTypeFileCopy, &fileCopyMsg, sizeof (fileCopyMsg));
+            sleepForUserspace();
+            _fileCopyPkt->header.status = this->status;
           }
-          userClientMsg.operation = (HyperVUserClientFileCopyOperation)fileCopyMsg->fcopyHeader.operation;
-          HVDBGLOG("Sending file copy operation type %u", fileCopyMsg->fcopyHeader.operation);
-          _hvDevice->getHvController()->notifyUserClient(kHyperVUserClientNotificationTypeFileCopy, &userClientMsg, sizeof (userClientMsg));
-          if (sleepForUserspace(15) == THREAD_TIMED_OUT) {
-            fileCopyMsg->header.status = kHyperVUserClientStatusTimedOut;
-            break;
-          }
-          fileCopyMsg->header.status = this->status;
-          
+          break;
+        case kHyperVUserClientFileCopyOperationCompleteFileCopy:
+        case kHyperVUserClientFileCopyOperationCancelFileCopy:
+          fileCopyMsg.operation = _fileCopyPkt->fcopyHeader.operation;
+          _hvDevice->getHvController()->notifyUserClient(kHyperVUserClientNotificationTypeFileCopy, &fileCopyMsg, sizeof (fileCopyMsg.operation));
           break;
         default:
-          HVDBGLOG("Unknown file copy operation type %u", fileCopyMsg->fcopyHeader.operation);
-          fileCopyMsg->header.status = kHyperVStatusFail;
+          HVDBGLOG("Unknown file copy operation type %u", _fileCopyPkt->fcopyHeader.operation);
+          _fileCopyPkt->header.status = kHyperVStatusFail;
           break;
       }
       break;
 
     default:
-      HVDBGLOG("Unknown file copy message type %u", fileCopyMsg->header.type);
-      fileCopyMsg->header.status = kHyperVStatusFail;
+      HVDBGLOG("Unknown file copy message type %u", _fileCopyPkt->header.type);
+      _fileCopyPkt->header.status = kHyperVStatusFail;
       break;
   }
 
   //
   // Send response back to Hyper-V. The packet size will always be the same as the original inbound one.
   //
-  fileCopyMsg->header.flags = kVMBusICFlagTransaction | kVMBusICFlagResponse;
-  _hvDevice->writeInbandPacket(fileCopyMsg, pktDataLength, false);
+  _fileCopyPkt->header.flags = kVMBusICFlagTransaction | kVMBusICFlagResponse;
+  _hvDevice->writeInbandPacket(_fileCopyPkt, pktDataLength, false);
 }
 
 int HyperVFileCopy::sleepForUserspace(UInt32 seconds) {
@@ -176,31 +156,119 @@ void HyperVFileCopy::wakeForUserspace() {
 }
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_6
-bool HyperVFileCopy::_userClientAvailable(void *target, void *ref, IOService *newService) {
+bool HyperVFileCopy::_userClientAvailable(void *target, void *ref, IOService *newService)
 #else
-bool HyperVFileCopy::_userClientAvailable(void *target, void *ref, IOService *newService, IONotifier *notifier) {
+bool HyperVFileCopy::_userClientAvailable(void *target, void *ref, IOService *newService, IONotifier *notifier)
 #endif
+{
   HyperVFileCopy *fcopy = (HyperVFileCopy *) target;
+  HyperVUserClientFileCopyMessage fileCopyMsg;
   if (fcopy) {
     fcopy->HVDBGLOG("User client is now available; attempting registration");
     if (!fcopy->_hvDevice->getHvController()->registerUserClientDriver(fcopy)) {
       fcopy->HVSYSLOG("Failed to register driver in user client");
-    } else { fcopy->isRegistered = true; }
+    } else {
+      fileCopyMsg.operation = kHyperVUserClientFileCopySetup;
+      IOSleep(2000);
+      fcopy->HVSYSLOG("Notifying user client to tell user-space to send a buffer for mapping.");
+      fcopy->_hvDevice->getHvController()->notifyUserClient(kHyperVUserClientNotificationTypeFileCopy, &fileCopyMsg, sizeof (fileCopyMsg.operation));
+      fcopy->isRegistered = true;
+    }
   }
+  
   return true;
 }
   
 IOReturn HyperVFileCopy::callPlatformFunction(const OSSymbol *functionName,
-                              bool waitForFunction, void *param1,
-                              void *param2, void *param3, void *param4) {
-  UInt64 *status;
-  if (functionName->isEqualTo("responseFromUserspace")) {
-    status = (UInt64 *) param1;
-    HVDBGLOG("Got response from userspace: 0x%x", *status);
-    this->status = *status;
-    wakeForUserspace();
+                                              bool waitForFunction, void *param1,
+                                              void *param2, void *param3, void *param4) {
+  HVDBGLOG("Calling function '%s'", functionName->getCStringNoCopy());
+  if (functionName->isEqualTo("mapSharedBuffer")) {
+    *(IOReturn *) param1 = mapSharedBuffer((task_t) param2, (mach_vm_address_t) param3, *(size_t *) param4);
+    return kIOReturnSuccess;
+  } else if (functionName->isEqualTo("returnCodeFromUserspace")) {
+    returnCodeFromUserspace((UInt64 *) param1);
+    return kIOReturnSuccess;
+  } else if (functionName->isEqualTo("getStartCopyData")) {
+    getStartCopyData((HyperVUserClientFileCopyStartCopyData *) param1);
     return kIOReturnSuccess;
   }
   return super::callPlatformFunction(functionName, waitForFunction,
                                      param1, param2, param3, param4);
+}
+
+IOReturn HyperVFileCopy::mapSharedBuffer(task_t task, mach_vm_address_t userBuffer, size_t userBufferSize) {
+  memoryDescriptor = IOMemoryDescriptor::withAddressRange(userBuffer, userBufferSize,
+                                                          kIODirectionNone, task);
+  if (!memoryDescriptor) {
+    HVSYSLOG("Failed to create memory descriptor");
+    return kIOReturnError;
+  }
+  
+  if (memoryDescriptor->prepare() != kIOReturnSuccess) {
+    HVSYSLOG("Failed to prepare memory descriptor");
+    memoryDescriptor->release();
+    memoryDescriptor = NULL;
+    return kIOReturnError;
+  }
+  
+  memoryMap = memoryDescriptor->createMappingInTask(kernel_task, 0, kIOMapAnywhere | kIOMapDefaultCache);
+  if (!memoryMap) {
+    HVSYSLOG("Failed to create memory mapping for memory descriptor");
+    memoryDescriptor->complete();
+    memoryDescriptor->release();
+    memoryDescriptor = NULL;
+    return kIOReturnError;
+  }
+  
+  userClientChunkBuffer = (UInt8 *) memoryMap->getVirtualAddress();
+  if (!userClientChunkBuffer) {
+    HVSYSLOG("Failed to get kernel address of mapped daemon file chunk buffer");
+    memoryDescriptor->complete();
+    memoryDescriptor->release();
+    memoryDescriptor = NULL;
+    memoryMap->release();
+    return kIOReturnError;
+  }
+  
+  HVDBGLOG("Successfully mapped daemon file chunk buffer");
+  return kIOReturnSuccess;
+}
+
+void HyperVFileCopy::returnCodeFromUserspace(UInt64 *status) {
+  HVDBGLOG("Got response from userspace: 0x%x", *status);
+  this->status = *status;
+  wakeForUserspace();
+}
+
+void HyperVFileCopy::getStartCopyData(HyperVUserClientFileCopyStartCopyData *startCopyDataOut) {
+  HVDBGLOG("Got request for file name and file path from userspace");
+  convertNameAndPath(_fileCopyPkt, startCopyDataOut);
+}
+
+bool HyperVFileCopy::convertNameAndPath(VMBusICMessageFileCopy *input, HyperVUserClientFileCopyStartCopyData *output) {
+  UInt8 unicodeNul[3] = { 0xE2, 0x90, 0x80 };
+  void *unicodeNulLoc;
+  size_t nlen;
+  size_t plen;
+  
+  memset(output->fileName, 0, PATH_MAX);
+  utf8_encodestr(input->startCopy.fileName, kHyperVFileCopyMaxPath * 2, (UInt8*)output->fileName, &nlen, PATH_MAX, '_', UTF_LITTLE_ENDIAN);
+  unicodeNulLoc = lilu_os_memmem((UInt8*)output->fileName, PATH_MAX, &unicodeNul, sizeof (unicodeNul));
+  if (!unicodeNulLoc) {
+    input->header.status = kHyperVStatusFail;
+    return false;
+  }
+  *(char *)unicodeNulLoc = 0x00;
+  
+  memset(output->filePath, 0, PATH_MAX);
+  utf8_encodestr(input->startCopy.filePath, kHyperVFileCopyMaxPath * 2, (UInt8*)output->filePath, &plen, PATH_MAX, '/', UTF_LITTLE_ENDIAN);
+  unicodeNulLoc = lilu_os_memmem((UInt8*)output->filePath, PATH_MAX, &unicodeNul, sizeof (unicodeNul));
+  if (!unicodeNulLoc) {
+    input->header.status = kHyperVStatusFail;
+    return false;
+  }
+  *(char *)unicodeNulLoc = 0x00;
+
+  return true;
 }

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
@@ -38,6 +38,9 @@ void HyperVFileCopy::stop(IOService *provider) {
 
 void HyperVFileCopy::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength) {
   VMBusICMessageFileCopy *fileCopyMsg = (VMBusICMessageFileCopy*) pktData;
+  HyperVUserClientFileCopy userClientMsg;
+  size_t nlen;
+  size_t plen;
 
   switch (fileCopyMsg->header.type) {
     case kVMBusICMessageTypeNegotiate:
@@ -57,10 +60,24 @@ void HyperVFileCopy::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeader
       }
       switch (fileCopyMsg->fcopyHeader.operation) {
         case kVMBusICFileCopyOperationStartFileCopy:
-          UInt8 pbuf[PATH_MAX];
-          size_t plen;
-          utf8_encodestr(fileCopyMsg->startCopy.fileName, kHyperVFileCopyMaxPath, (UInt8*)&pbuf, &plen, PATH_MAX, 0, 0);
-          HVSYSLOG("File copy attempted for file: %s", &pbuf);
+        case kVMBusICFileCopyOperationWriteToFile:
+        case kVMBusICFileCopyOperationCompleteFileCopy:
+        case kVMBusICFileCopyOperationCancelFileCopy:
+          memset(&userClientMsg, 0, sizeof (userClientMsg));
+          if (fileCopyMsg->fcopyHeader.operation == kVMBusICFileCopyOperationStartFileCopy) {
+            memset(&userClientMsg.operationData.startCopy.fileName, 0, PATH_MAX);
+            utf8_encodestr(fileCopyMsg->startCopy.fileName, kHyperVFileCopyMaxPath, (UInt8*)&userClientMsg.operationData.startCopy.fileName, &nlen, PATH_MAX, 0, 0);
+            memset(&userClientMsg.operationData.startCopy.filePath, 0, PATH_MAX);
+            utf8_encodestr(fileCopyMsg->startCopy.filePath, kHyperVFileCopyMaxPath, (UInt8*)&userClientMsg.operationData.startCopy.filePath, &plen, PATH_MAX, 0, 0);
+            userClientMsg.operationData.startCopy.fileSize = fileCopyMsg->startCopy.fileSize;
+            userClientMsg.operationData.startCopy.copyFlags = (HyperVUserClientFileCopyFlags)fileCopyMsg->startCopy.copyFlags;
+            HVSYSLOG("File copy attempted for file %s at path %s", &userClientMsg.operationData.startCopy.fileName, &userClientMsg.operationData.startCopy.filePath);
+          } else {
+            memcpy(&userClientMsg.operationData, fileCopyMsg + sizeof (VMBusICMessageFileCopyHeader), pktDataLength - sizeof (VMBusICMessageFileCopyHeader));
+          }
+          userClientMsg.operation = (HyperVUserClientFileCopyOperation)fileCopyMsg->fcopyHeader.operation;
+          _hvDevice->getHvController()->notifyUserClient(kHyperVUserClientNotificationTypeFileCopy, &userClientMsg, sizeof (userClientMsg));
+          
           break;
         default:
           HVDBGLOG("Unknown file copy operation type %u", fileCopyMsg->fcopyHeader.operation);

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.cpp
@@ -152,7 +152,7 @@ int HyperVFileCopy::sleepForUserspace(UInt32 seconds) {
   HVDBGLOG("Sleeping until response from userspace", status);
   isSleeping = true;
   IOLockLock(lock);
-  while (isSleeping) {
+  while (isSleeping && waitResult != THREAD_TIMED_OUT) {
     if (seconds) {
       if (computeDeadline) {
         clock_interval_to_deadline(seconds, kSecondScale, &deadline);

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
@@ -43,6 +43,7 @@ private:
 #endif
   void returnCodeFromUserspace(UInt64 *status);
   void getStartCopyData(HyperVUserClientFileCopyStartCopyData *startCopyDataOut);
+  void getDoCopyData(HyperVUserClientFileCopyDoCopyData *doCopyDataOut);
   bool convertNameAndPath(VMBusICMessageFileCopy *input, HyperVUserClientFileCopyStartCopyData *output);
 
 public:

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
@@ -1,0 +1,35 @@
+//
+//  HyperVFileCopy.hpp
+//  Hyper-V file copy driver
+//
+//  Copyright © 2022 flagers. All rights reserved.
+//
+
+#ifndef HyperVFileCopy_hpp
+#define HyperVFileCopy_hpp
+
+#include "HyperVICService.hpp"
+#include "HyperVFileCopyRegs.hpp"
+#include <sys/syslimits.h>
+#include <sys/utfconv.h>
+
+class HyperVFileCopy : public HyperVICService {
+  OSDeclareDefaultStructors(HyperVFileCopy);
+  HVDeclareLogFunctionsVMBusChild("fcopy");
+  typedef HyperVICService super;
+
+private:
+  bool firstFileCopyReceived = false;
+
+protected:
+  void handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength) APPLE_KEXT_OVERRIDE;
+
+public:
+  //
+  // IOService overrides.
+  //
+  bool start(IOService *provider) APPLE_KEXT_OVERRIDE;
+  void stop(IOService *provider) APPLE_KEXT_OVERRIDE;
+};
+
+#endif

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
@@ -18,9 +18,6 @@ class HyperVFileCopy : public HyperVICService {
   HVDeclareLogFunctionsVMBusChild("fcopy");
   typedef HyperVICService super;
 
-private:
-  bool firstFileCopyReceived = false;
-
 protected:
   void handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength) APPLE_KEXT_OVERRIDE;
 

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
@@ -21,12 +21,21 @@ class HyperVFileCopy : public HyperVICService {
 protected:
   void handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength) APPLE_KEXT_OVERRIDE;
 
+private:
+  UInt32 status;
+  IOLock *lock = nullptr;
+  bool isSleeping = false;
+  void sleepForUserspace();
+  void wakeForUserspace();
+
 public:
   //
   // IOService overrides.
   //
   bool start(IOService *provider) APPLE_KEXT_OVERRIDE;
   void stop(IOService *provider) APPLE_KEXT_OVERRIDE;
+  
+  static void responseFromUserspace(int *status);
 };
 
 #endif

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
@@ -29,6 +29,12 @@ private:
   bool isSleeping = false;
   IONotifier *_userClientNotify;
   bool isRegistered = false;
+  VMBusICMessageFileCopy *_fileCopyPkt;
+  
+  IOMemoryDescriptor *memoryDescriptor = NULL;
+  IOMemoryMap        *memoryMap = NULL;
+  UInt8              *userClientChunkBuffer;
+  
   int sleepForUserspace(UInt32 seconds = 0);
   void wakeForUserspace();
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_6
@@ -39,6 +45,10 @@ private:
                                    IOService *newService,
                                    IONotifier *notifier);
 #endif
+  IOReturn mapSharedBuffer(task_t task, mach_vm_address_t userBuffer, size_t userBufferSize);
+  void returnCodeFromUserspace(UInt64 *status);
+  void getStartCopyData(HyperVUserClientFileCopyStartCopyData *startCopyDataOut);
+  bool convertNameAndPath(VMBusICMessageFileCopy *input, HyperVUserClientFileCopyStartCopyData *output);
 
 public:
   //

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
@@ -25,8 +25,18 @@ private:
   UInt32 status;
   IOLock *lock = nullptr;
   bool isSleeping = false;
-  void sleepForUserspace();
+  IONotifier *_userClientNotify;
+  bool isRegistered = false;
+  int sleepForUserspace(UInt32 seconds = 0);
   void wakeForUserspace();
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_6
+  static bool _userClientAvailable(void *target, void *ref,
+                                   IOService *newService);
+#else
+  static bool _userClientAvailable(void *target, void *ref,
+                                   IOService *newService,
+                                   IONotifier *notifier);
+#endif
 
 public:
   //
@@ -34,8 +44,10 @@ public:
   //
   bool start(IOService *provider) APPLE_KEXT_OVERRIDE;
   void stop(IOService *provider) APPLE_KEXT_OVERRIDE;
-  
-  static void responseFromUserspace(int *status);
+  IOReturn callPlatformFunction(const OSSymbol *functionName,
+                                bool waitForFunction, void *param1,
+                                void *param2, void *param3,
+                                void *param4) APPLE_KEXT_OVERRIDE;
 };
 
 #endif

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
@@ -20,6 +20,8 @@ class HyperVFileCopy : public HyperVICService {
 
 protected:
   void handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength) APPLE_KEXT_OVERRIDE;
+  UInt32 txBufferSize() APPLE_KEXT_OVERRIDE { return kHyperVFileCopyBufferSize; };
+  UInt32 rxBufferSize() APPLE_KEXT_OVERRIDE { return kHyperVFileCopyBufferSize; };
 
 private:
   UInt32 status;

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopy.hpp
@@ -31,10 +31,6 @@ private:
   bool isRegistered = false;
   VMBusICMessageFileCopy *_fileCopyPkt;
   
-  IOMemoryDescriptor *memoryDescriptor = NULL;
-  IOMemoryMap        *memoryMap = NULL;
-  UInt8              *userClientChunkBuffer;
-  
   int sleepForUserspace(UInt32 seconds = 0);
   void wakeForUserspace();
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_6
@@ -45,7 +41,6 @@ private:
                                    IOService *newService,
                                    IONotifier *notifier);
 #endif
-  IOReturn mapSharedBuffer(task_t task, mach_vm_address_t userBuffer, size_t userBufferSize);
   void returnCodeFromUserspace(UInt64 *status);
   void getStartCopyData(HyperVUserClientFileCopyStartCopyData *startCopyDataOut);
   bool convertNameAndPath(VMBusICMessageFileCopy *input, HyperVUserClientFileCopyStartCopyData *output);

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopyRegs.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopyRegs.hpp
@@ -49,7 +49,7 @@ typedef struct __attribute__((packed)) {
   // fileName & filePath are UTF-16 strings
   UInt16                        fileName[kHyperVFileCopyMaxPath];
   UInt16                        filePath[kHyperVFileCopyMaxPath];
-  UInt32                        copyFlags;
+  VMBusICFileCopyFlags          copyFlags;
   UInt64                        fileSize;
 } VMBusICMessageFileCopyStartCopy;
 

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopyRegs.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopyRegs.hpp
@@ -12,6 +12,7 @@
 
 #define kHyperVFileCopyMaxPath       260
 #define kHyperVFileCopyFragmentSize  (6 * 1024)
+#define kHyperVFileCopyBufferSize    (8 * PAGE_SIZE)
 
 //
 // File Copy versions.

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopyRegs.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopyRegs.hpp
@@ -1,0 +1,75 @@
+//
+//  HyperVFileCopyRegs.hpp
+//  Hyper-V file copy driver
+//
+//  Copyright © 2022 flagers. All rights reserved.
+//
+
+#ifndef HyperVFileCopyRegs_hpp
+#define HyperVFileCopyRegs_hpp
+
+#include "HyperVIC.hpp"
+
+#define kHyperVFileCopyMaxPath       260
+#define kHyperVFileCopyFragmentSize  (6 * 1024)
+
+//
+// File Copy versions.
+//
+#define kHyperVFileCopyVersionV1 { 1, 1 }
+
+//
+// File Copy operations.
+//
+typedef enum : UInt32 {
+  kVMBusICFileCopyOperationStartFileCopy    = 0,
+  kVMBusICFileCopyOperationWriteToFile      = 1,
+  kVMBusICFileCopyOperationCompleteFileCopy = 2,
+  kVMBusICFileCopyOperationCancelFileCopy   = 3
+} VMBusICFileCopyOperation;
+
+//
+// File Copy messages.
+//
+typedef struct __attribute__((packed)) {
+  VMBusICMessageHeader      header;
+  
+  VMBusICFileCopyOperation  operation;
+  uuid_t                    unused1;
+  uuid_t                    unused2;
+} VMBusICMessageFileCopyHeader;
+
+typedef enum : UInt32 {
+  kVMBusICFileCopyFlagsOverwrite    = 1,
+  kVMBusICFileCopyFlagsCreatePath   = 2
+} VMBusICFileCopyFlags;
+
+typedef struct __attribute__((packed)) {
+  VMBusICMessageFileCopyHeader  fcopyHeader;
+  // fileName & filePath are UTF-16 strings
+  UInt16                        fileName[kHyperVFileCopyMaxPath];
+  UInt16                        filePath[kHyperVFileCopyMaxPath];
+  UInt32                        copyFlags;
+  UInt64                        fileSize;
+} VMBusICMessageFileCopyStartCopy;
+
+typedef struct __attribute__((packed)) {
+  VMBusICMessageFileCopyHeader  fcopyHeader;
+  UInt32                        reserved;
+  UInt64                        offset;
+  UInt32                        size;
+  UInt8                         data[kHyperVFileCopyFragmentSize];
+} VMBusICMessageFileCopyDoCopy;
+
+typedef struct __attribute__((packed)) {
+  union {
+    VMBusICMessageHeader             header;
+    VMBusICMessageNegotiate          negotiate;
+
+    VMBusICMessageFileCopyHeader     fcopyHeader;
+    VMBusICMessageFileCopyStartCopy  startCopy;
+    VMBusICMessageFileCopyDoCopy     doCopy;
+  };
+} VMBusICMessageFileCopy;
+
+#endif

--- a/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopyRegs.hpp
+++ b/MacHyperVSupport/IntegrationComponents/FileCopy/HyperVFileCopyRegs.hpp
@@ -9,9 +9,9 @@
 #define HyperVFileCopyRegs_hpp
 
 #include "HyperVIC.hpp"
+#include "HyperVUserClient.h"
 
 #define kHyperVFileCopyMaxPath       260
-#define kHyperVFileCopyFragmentSize  (6 * 1024)
 #define kHyperVFileCopyBufferSize    (8 * PAGE_SIZE)
 
 //
@@ -20,38 +20,23 @@
 #define kHyperVFileCopyVersionV1 { 1, 1 }
 
 //
-// File Copy operations.
-//
-typedef enum : UInt32 {
-  kVMBusICFileCopyOperationStartFileCopy    = 0,
-  kVMBusICFileCopyOperationWriteToFile      = 1,
-  kVMBusICFileCopyOperationCompleteFileCopy = 2,
-  kVMBusICFileCopyOperationCancelFileCopy   = 3
-} VMBusICFileCopyOperation;
-
-//
 // File Copy messages.
 //
 typedef struct __attribute__((packed)) {
-  VMBusICMessageHeader      header;
+  VMBusICMessageHeader               header;
   
-  VMBusICFileCopyOperation  operation;
-  uuid_t                    unused1;
-  uuid_t                    unused2;
+  HyperVUserClientFileCopyOperation  operation;
+  uuid_t                             unused1;
+  uuid_t                             unused2;
 } VMBusICMessageFileCopyHeader;
 
-typedef enum : UInt32 {
-  kVMBusICFileCopyFlagsOverwrite    = 1,
-  kVMBusICFileCopyFlagsCreatePath   = 2
-} VMBusICFileCopyFlags;
-
 typedef struct __attribute__((packed)) {
-  VMBusICMessageFileCopyHeader  fcopyHeader;
+  VMBusICMessageFileCopyHeader   fcopyHeader;
   // fileName & filePath are UTF-16 strings
-  UInt16                        fileName[kHyperVFileCopyMaxPath];
-  UInt16                        filePath[kHyperVFileCopyMaxPath];
-  VMBusICFileCopyFlags          copyFlags;
-  UInt64                        fileSize;
+  UInt16                         fileName[kHyperVFileCopyMaxPath];
+  UInt16                         filePath[kHyperVFileCopyMaxPath];
+  HyperVUserClientFileCopyFlags  copyFlags;
+  UInt64                         fileSize;
 } VMBusICMessageFileCopyStartCopy;
 
 typedef struct __attribute__((packed)) {

--- a/MacHyperVSupport/IntegrationComponents/HyperVICService.cpp
+++ b/MacHyperVSupport/IntegrationComponents/HyperVICService.cpp
@@ -51,7 +51,7 @@ bool HyperVICService::start(IOService *provider) {
     //
     // Open VMBus channel
     //
-    status = _hvDevice->openVMBusChannel(kHyperVICBufferSize, kHyperVICBufferSize);
+    status = _hvDevice->openVMBusChannel(txBufferSize(), rxBufferSize());
     if (status != kIOReturnSuccess) {
       HVSYSLOG("Failed to open VMBus channel with status 0x%X", status);
       break;

--- a/MacHyperVSupport/IntegrationComponents/HyperVICService.hpp
+++ b/MacHyperVSupport/IntegrationComponents/HyperVICService.hpp
@@ -25,6 +25,8 @@ protected:
   void setICDebug(bool debug) { debugEnabled = debug; }
 
   virtual void handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength) = 0;
+  virtual UInt32 txBufferSize() { return kHyperVICBufferSize; };
+  virtual UInt32 rxBufferSize() { return kHyperVICBufferSize; };
   bool processNegotiationResponse(VMBusICMessageNegotiate *negMsg, const VMBusICVersion *msgVersions,
                                   UInt32 msgVersionsCount, VMBusICVersion *msgVersionUsed = nullptr);
 

--- a/Tools/hvutil/hvutil.c
+++ b/Tools/hvutil/hvutil.c
@@ -10,6 +10,8 @@
 
 #include <sys/time.h>
 
+#include <iconv.h>
+
 #include "hvdebug.h"
 #include "HyperVUserClient.h"
 
@@ -72,15 +74,67 @@ static void hvUtilDoTimeSync(void *data, UInt32 dataLength) {
   settimeofday(&timeValData, NULL);
 }
 
+static void hvUtilFileCopyStartCopy(HyperVUserClientFileCopyStartCopy *startCopyMsg) {
+  UInt16 *origFileName;
+  UInt16 *origFilePath;
+  UInt8 *utf8FileName;
+  UInt8 *utf8FilePath;
+  UInt8 *utf8FileNameOrig;
+  UInt8 *utf8FilePathOrig;
+  size_t origFileNameSize = sizeof (startCopyMsg->fileName);
+  size_t utf8FileNameSize = sizeof (startCopyMsg->fileName) / 2;
+  size_t origFilePathSize = sizeof (startCopyMsg->filePath);
+  size_t utf8FilePathSize = sizeof (startCopyMsg->filePath) / 2;
+  
+  iconv_t iconvFcopy = iconv_open("UTF-8", "UTF-16LE");
+  if ((int) iconvFcopy == -1) {
+    if (errno == EINVAL) { HVDBGLOG(stderr, "Unsupported conversion"); }
+    else { HVDBGLOG(stderr, "Initialization failure"); }
+  }
+  
+  origFileName = &startCopyMsg->fileName;
+  origFilePath = &startCopyMsg->filePath;
+  utf8FileName = malloc(utf8FileNameSize);
+  utf8FilePath = malloc(utf8FilePathSize);
+  memset(utf8FileName, 0, utf8FileNameSize);
+  memset(utf8FilePath, 0, utf8FilePathSize);
+  utf8FileNameOrig = utf8FileName;
+  utf8FilePathOrig = utf8FilePath;
+  
+  
+  int ret1 = iconv(iconvFcopy, &origFileName, &origFileNameSize, &utf8FileName, &utf8FileNameSize);
+  int ret2 = iconv(iconvFcopy, NULL, NULL, NULL, NULL);
+  int ret3 = iconv(iconvFcopy, &origFilePath, &origFilePathSize, &utf8FilePath, &utf8FilePathSize);
+  
+  if (ret1 == (iconv_t) -1 || ret2 == (iconv_t) -1 || ret3 == (iconv_t) -1) {
+    HVSYSLOG(stderr, "Failed to convert with iconv");
+    free(utf8FileNameOrig);
+    free(utf8FilePathOrig);
+    iconv_close(iconvFcopy);
+    return;
+  }
+  
+  HVSYSLOG(stdout, "%s | %s", utf8FileNameOrig, utf8FilePathOrig);
+  free(utf8FileNameOrig);
+  free(utf8FilePathOrig);
+  iconv_close(iconvFcopy);
+}
+
 static void hvUtilFileCopy(void *data, UInt32 dataLength) {
   HyperVUserClientFileCopy *fcopyMsg;
-  if (dataLength > sizeof (HyperVUserClientFileCopy)) {
-    HVSYSLOG(stderr, "Packet larger than expected");
+  if (dataLength > sizeof (*fcopyMsg)) {
+    HVSYSLOG(stderr, "File copy packet larger than expected");
     return;
   }
   fcopyMsg = (HyperVUserClientFileCopy *) data;
   
-  HVSYSLOG(stdout, "%s | %s", fcopyMsg->operationData.startCopy.fileName, fcopyMsg->operationData.startCopy.filePath);
+  switch (fcopyMsg->operation) {
+    case kHyperVUserClientFileCopyOperationStartFileCopy:
+      hvUtilFileCopyStartCopy(&fcopyMsg->operationData.startCopy);
+    default:
+      HVDBGLOG(stdout, "Unknown file copy operation type 0x%X", fcopyMsg->operation);
+      break;
+  }
 }
 
 static void hvUtilNotification(CFMachPortRef port, void *msg, CFIndex size, void *info) {

--- a/Tools/hvutil/hvutil.c
+++ b/Tools/hvutil/hvutil.c
@@ -201,24 +201,24 @@ static void hvUtilFileCopy(void *data, UInt32 dataLength) {
 
 static void hvUtilNotification(CFMachPortRef port, void *msg, CFIndex size, void *info) {
   HyperVUserClientNotificationMessage *hvMsg = (HyperVUserClientNotificationMessage *) msg;
-  HVDBGLOG(stdout, "Received notification of type 0x%X", hvMsg->standard.type);
+  HVDBGLOG(stdout, "Received notification of type 0x%X", hvMsg->type);
 
-  switch (hvMsg->standard.type) {
+  switch (hvMsg->type) {
     case kHyperVUserClientNotificationTypePerformShutdown:
     case kHyperVUserClientNotificationTypePerformRestart:
-      hvUtilDoShutdown(hvMsg->standard.type == kHyperVUserClientNotificationTypePerformRestart);
+      hvUtilDoShutdown(hvMsg->type == kHyperVUserClientNotificationTypePerformRestart);
       break;
       
     case kHyperVUserClientNotificationTypeTimeSync:
-      hvUtilDoTimeSync(hvMsg->standard.data, hvMsg->standard.dataLength);
+      hvUtilDoTimeSync(hvMsg->data, hvMsg->dataLength);
       break;
     
     case kHyperVUserClientNotificationTypeFileCopy:
-      hvUtilFileCopy(hvMsg->large.data, hvMsg->large.dataLength);
+      hvUtilFileCopy(hvMsg->data, hvMsg->dataLength);
       break;
 
     default:
-      HVDBGLOG(stdout, "Unknown notification type 0x%X", hvMsg->standard.type);
+      HVDBGLOG(stdout, "Unknown notification type 0x%X", hvMsg->type);
       break;
   }
 }


### PR DESCRIPTION
Changes implemented in this pull request:
* New HyperVFileCopy Integration Service driver
* Changes to HyperVUserClient in order to facilitate user-space -> kernel communication (`IOExternalMethod*`)
* Changes to HyperVUserClient in order to facilitate callbacks to peer integration service drivers (`registerDriver()`)
* Support implemented in `hvutil` daemon for HyperVFileCopy driver