### PR TITLE
[WIP] Balloon (Hyper-V Dynamic Memory) support

### DIFF
--- a/MacHyperVSupport.xcodeproj/project.pbxproj
+++ b/MacHyperVSupport.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		234FF910295F4C4C00BD4EA5 /* HyperVBalloon.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 234FF90C295F4C4C00BD4EA5 /* HyperVBalloon.hpp */; };
+		234FF911295F4C4C00BD4EA5 /* HyperVBalloon.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 234FF90C295F4C4C00BD4EA5 /* HyperVBalloon.hpp */; };
+		234FF912295F4C4C00BD4EA5 /* HyperVBalloonPrivate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 234FF90D295F4C4C00BD4EA5 /* HyperVBalloonPrivate.cpp */; };
+		234FF913295F4C4C00BD4EA5 /* HyperVBalloonPrivate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 234FF90D295F4C4C00BD4EA5 /* HyperVBalloonPrivate.cpp */; };
+		234FF914295F4C4C00BD4EA5 /* HyperVBalloonRegs.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 234FF90E295F4C4C00BD4EA5 /* HyperVBalloonRegs.hpp */; };
+		234FF915295F4C4C00BD4EA5 /* HyperVBalloonRegs.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 234FF90E295F4C4C00BD4EA5 /* HyperVBalloonRegs.hpp */; };
+		234FF916295F4C4C00BD4EA5 /* HyperVBalloon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 234FF90F295F4C4C00BD4EA5 /* HyperVBalloon.cpp */; };
+		234FF917295F4C4C00BD4EA5 /* HyperVBalloon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 234FF90F295F4C4C00BD4EA5 /* HyperVBalloon.cpp */; };
 		410F5CC828C58D1800EBB105 /* HyperVVMBusPrivate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 410F5CC728C58D1800EBB105 /* HyperVVMBusPrivate.cpp */; };
 		410F5CC928C58D1800EBB105 /* HyperVVMBusPrivate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 410F5CC728C58D1800EBB105 /* HyperVVMBusPrivate.cpp */; };
 		41225F512644C34300574E86 /* HyperVVMBusDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 41225F4F2644C34300574E86 /* HyperVVMBusDevice.cpp */; };
@@ -272,6 +280,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		234FF90C295F4C4C00BD4EA5 /* HyperVBalloon.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = HyperVBalloon.hpp; path = MacHyperVSupport/Balloon/HyperVBalloon.hpp; sourceTree = SOURCE_ROOT; };
+		234FF90D295F4C4C00BD4EA5 /* HyperVBalloonPrivate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HyperVBalloonPrivate.cpp; path = MacHyperVSupport/Balloon/HyperVBalloonPrivate.cpp; sourceTree = SOURCE_ROOT; };
+		234FF90E295F4C4C00BD4EA5 /* HyperVBalloonRegs.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = HyperVBalloonRegs.hpp; path = MacHyperVSupport/Balloon/HyperVBalloonRegs.hpp; sourceTree = SOURCE_ROOT; };
+		234FF90F295F4C4C00BD4EA5 /* HyperVBalloon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HyperVBalloon.cpp; path = MacHyperVSupport/Balloon/HyperVBalloon.cpp; sourceTree = SOURCE_ROOT; };
 		410F5CC728C58D1800EBB105 /* HyperVVMBusPrivate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HyperVVMBusPrivate.cpp; sourceTree = "<group>"; };
 		41225F4226422D1600574E86 /* VMBus.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = VMBus.hpp; sourceTree = "<group>"; };
 		41225F4D2643993400574E86 /* HyperV.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = HyperV.hpp; sourceTree = "<group>"; };
@@ -451,6 +463,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		234FF905295F34C200BD4EA5 /* Balloon */ = {
+			isa = PBXGroup;
+			children = (
+				234FF90F295F4C4C00BD4EA5 /* HyperVBalloon.cpp */,
+				234FF90C295F4C4C00BD4EA5 /* HyperVBalloon.hpp */,
+				234FF90D295F4C4C00BD4EA5 /* HyperVBalloonPrivate.cpp */,
+				234FF90E295F4C4C00BD4EA5 /* HyperVBalloonRegs.hpp */,
+			);
+			name = Balloon;
+			path = ../Balloon;
+			sourceTree = "<group>";
+		};
 		411FB8FC289DD2FF0063EF4E /* Heartbeat */ = {
 			isa = PBXGroup;
 			children = (
@@ -661,6 +685,7 @@
 				41BE410B263EDE380018C52B /* Info.plist */,
 				41F2E4272665B4C100CE26CE /* kern_start.cpp */,
 				41AE1CFF28974C7E001A7B42 /* package.tool */,
+				234FF905295F34C200BD4EA5 /* Balloon */,
 				41E5E20928C5765300E6E84F /* Controller */,
 				41AE1D0B289C9595001A7B42 /* CPU */,
 				41F2E4392666E62F00CE26CE /* GraphicsBridge */,
@@ -875,6 +900,7 @@
 				4191F70E28F5057F00809232 /* HyperVFileCopyUserClientInternal.hpp in Headers */,
 				41F2E4012665B42200CE26CE /* kern_version.hpp in Headers */,
 				41F2E43D2666E6A100CE26CE /* HyperVGraphicsBridge.hpp in Headers */,
+				234FF910295F4C4C00BD4EA5 /* HyperVBalloon.hpp in Headers */,
 				41F2E4132665B42200CE26CE /* kern_util.hpp in Headers */,
 				41F2E3FF2665B42200CE26CE /* kern_crypto.hpp in Headers */,
 				41F2E3F62665B42200CE26CE /* kern_time.hpp in Headers */,
@@ -916,6 +942,7 @@
 				41F2E4092665B42200CE26CE /* systemz.h in Headers */,
 				412E10A228C589DF00B8A699 /* HyperVVMBus.hpp in Headers */,
 				41F2E4002665B42200CE26CE /* kern_mach.hpp in Headers */,
+				234FF914295F4C4C00BD4EA5 /* HyperVBalloonRegs.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -938,6 +965,7 @@
 				4191F70F28F5057F00809232 /* HyperVFileCopyUserClientInternal.hpp in Headers */,
 				41BF45E2288CDF1200813670 /* ppc.h in Headers */,
 				41BF45E3288CDF1200813670 /* kern_version.hpp in Headers */,
+				234FF911295F4C4C00BD4EA5 /* HyperVBalloon.hpp in Headers */,
 				41BF45E4288CDF1200813670 /* HyperVGraphicsBridge.hpp in Headers */,
 				41BF45E5288CDF1200813670 /* kern_util.hpp in Headers */,
 				41BF45E6288CDF1200813670 /* kern_crypto.hpp in Headers */,
@@ -979,6 +1007,7 @@
 				41BF4606288CDF1200813670 /* systemz.h in Headers */,
 				412E10A328C589DF00B8A699 /* HyperVVMBus.hpp in Headers */,
 				41BF4607288CDF1200813670 /* kern_mach.hpp in Headers */,
+				234FF915295F4C4C00BD4EA5 /* HyperVBalloonRegs.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1227,6 +1256,7 @@
 				416E418E2651E42E006DED6D /* HyperVMousePrivate.cpp in Sources */,
 				41F47BE9290EC06E00C0E3C5 /* HyperVGraphicsBridgePrivate.cpp in Sources */,
 				41AE1D0E289C95A9001A7B42 /* HyperVCPU.cpp in Sources */,
+				234FF916295F4C4C00BD4EA5 /* HyperVBalloon.cpp in Sources */,
 				416E4180264A0D5D006DED6D /* HyperVStoragePrivate.cpp in Sources */,
 				41F2E43C2666E6A100CE26CE /* HyperVGraphicsBridge.cpp in Sources */,
 				417CEDD428E22C5400D0F6A8 /* HyperVTimeSync.cpp in Sources */,
@@ -1242,6 +1272,7 @@
 				41B41BDD26C74B4C00926A0D /* HyperVNetwork.cpp in Sources */,
 				41B41BE726CDC42D00926A0D /* HyperVNetworkRNDIS.cpp in Sources */,
 				41F9B8F02849792200E0DCB2 /* HyperVPCIBridge.cpp in Sources */,
+				234FF912295F4C4C00BD4EA5 /* HyperVBalloonPrivate.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1272,6 +1303,7 @@
 				41BF4615288CDF1200813670 /* HyperVMousePrivate.cpp in Sources */,
 				41F47BEA290EC06E00C0E3C5 /* HyperVGraphicsBridgePrivate.cpp in Sources */,
 				41AE1D0F289C95A9001A7B42 /* HyperVCPU.cpp in Sources */,
+				234FF917295F4C4C00BD4EA5 /* HyperVBalloon.cpp in Sources */,
 				41BF4617288CDF1200813670 /* HyperVStoragePrivate.cpp in Sources */,
 				41BF4618288CDF1200813670 /* HyperVGraphicsBridge.cpp in Sources */,
 				417CEDD528E22C5400D0F6A8 /* HyperVTimeSync.cpp in Sources */,
@@ -1287,6 +1319,7 @@
 				41BF4621288CDF1200813670 /* HyperVNetwork.cpp in Sources */,
 				41BF4622288CDF1200813670 /* HyperVNetworkRNDIS.cpp in Sources */,
 				41BF4623288CDF1200813670 /* HyperVPCIBridge.cpp in Sources */,
+				234FF913295F4C4C00BD4EA5 /* HyperVBalloonPrivate.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacHyperVSupport/Balloon/HyperVBalloon.cpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloon.cpp
@@ -67,14 +67,14 @@ bool HyperVBalloon::start(IOService *provider) {
     }
 
     //
-    // Initialize work loop and command gate.
+    // Initialize work loop and timer event source.
     //
     _workLoop = IOWorkLoop::workLoop();
     if (_workLoop == nullptr) {
       HVSYSLOG("Failed to initialize work loop");
       break;
     }
-    
+
     _timerSource = IOTimerEventSource::timerEventSource(this, OSMemberFunctionCast(IOTimerEventSource::Action, this, &HyperVBalloon::sendStatusReport));
     if (_timerSource == nullptr) {
       HVSYSLOG("Failed to initialize timed event source");
@@ -82,7 +82,7 @@ bool HyperVBalloon::start(IOService *provider) {
     }
     _workLoop->addEventSource(_timerSource);
     _timerSource->setTimeoutMS(kHyperVDynamicMemoryStatusReportIntervalMilliseconds);
-    
+
     HVDBGLOG("Initialized Hyper-V Dynamic Memory");
     result = true;
   } while (false);

--- a/MacHyperVSupport/Balloon/HyperVBalloon.cpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloon.cpp
@@ -1,0 +1,114 @@
+//
+//  HyperVBalloon.cpp
+//  Hyper-V balloon driver implementation
+//
+//  Copyright © 2022-2023 xdqi. All rights reserved.
+//
+
+#include "HyperVBalloon.hpp"
+#include "HyperVBalloonRegs.hpp"
+
+bool HyperVBalloon::start(IOService *provider) {
+  bool     result = false;
+  IOReturn status;
+
+  //
+  // Get parent VMBus device object.
+  //
+  _hvDevice = OSDynamicCast(HyperVVMBusDevice, provider);
+  if (_hvDevice == nullptr) {
+    HVSYSLOG("Provider is not HyperVVMBusDevice");
+    return false;
+  }
+  _hvDevice->retain();
+
+  HVCheckDebugArgs();
+  HVDBGLOG("Initializing Hyper-V Dynamic Memory");
+
+  if (HVCheckOffArg()) {
+    HVSYSLOG("Disabling Hyper-V Dynamic Memory due to boot arg");
+    OSSafeReleaseNULL(_hvDevice);
+    return false;
+  }
+
+  if (!super::start(provider)) {
+    HVSYSLOG("super::start() returned false");
+    OSSafeReleaseNULL(_hvDevice);
+    return false;
+  }
+
+  do {
+    //
+    // Install packet handler.
+    //
+    status = _hvDevice->installPacketActions(this, OSMemberFunctionCast(HyperVVMBusDevice::PacketReadyAction, this, &HyperVBalloon::handlePacket), nullptr, kHyperVDynamicMemoryResponsePacketSize);
+    if (status != kIOReturnSuccess) {
+      HVSYSLOG("Failed to install packet handler with status 0x%X", status);
+      break;
+    }
+
+    //
+    // Open VMBus channel.
+    //
+    status = _hvDevice->openVMBusChannel(kHyperVDynamicMemoryBufferSize, kHyperVDynamicMemoryBufferSize);
+    if (status != kIOReturnSuccess) {
+      HVSYSLOG("Failed to open VMBus channel with status 0x%X", status);
+      break;
+    }
+
+    //
+    // Configure Hyper-V Dynamic Memory device.
+    //
+    if (!setupBalloon()) {
+      HVSYSLOG("Unable to setup balloon device");
+      break;
+    }
+
+    //
+    // Initialize work loop and command gate.
+    //
+    _workLoop = IOWorkLoop::workLoop();
+    if (_workLoop == nullptr) {
+      HVSYSLOG("Failed to initialize work loop");
+      break;
+    }
+    
+    _timerSource = IOTimerEventSource::timerEventSource(this, OSMemberFunctionCast(IOTimerEventSource::Action, this, &HyperVBalloon::sendStatusReport));
+    if (_timerSource == nullptr) {
+      HVSYSLOG("Failed to initialize timed event source");
+      break;
+    }
+    _workLoop->addEventSource(_timerSource);
+    _timerSource->setTimeoutMS(kHyperVDynamicMemoryStatusReportIntervalMilliseconds);
+    
+    HVDBGLOG("Initialized Hyper-V Dynamic Memory");
+    result = true;
+  } while (false);
+
+  if (!result) {
+    _hvDevice->closeVMBusChannel();
+    _hvDevice->uninstallPacketActions();
+    OSSafeReleaseNULL(_hvDevice);
+  }
+
+  return result;
+}
+
+void HyperVBalloon::stop(IOService *provider) {
+  HVDBGLOG("Hyper-V Dynamic Memory is stopping");
+
+  if (_hvDevice != nullptr) {
+    _hvDevice->closeVMBusChannel();
+    _hvDevice->uninstallPacketActions();
+    OSSafeReleaseNULL(_hvDevice);
+  }
+
+  if (_timerSource != nullptr) {
+    _workLoop->removeEventSource(_timerSource);
+    _timerSource->cancelTimeout();
+    OSSafeReleaseNULL(_timerSource);
+  }
+  OSSafeReleaseNULL(_workLoop);
+  
+  super::stop(provider);
+}

--- a/MacHyperVSupport/Balloon/HyperVBalloon.cpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloon.cpp
@@ -8,6 +8,8 @@
 #include "HyperVBalloon.hpp"
 #include "HyperVBalloonRegs.hpp"
 
+OSDefineMetaClassAndStructors(HyperVBalloon, super);
+
 bool HyperVBalloon::start(IOService *provider) {
   bool     result = false;
   IOReturn status;

--- a/MacHyperVSupport/Balloon/HyperVBalloon.cpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloon.cpp
@@ -86,9 +86,7 @@ bool HyperVBalloon::start(IOService *provider) {
   } while (false);
 
   if (!result) {
-    _hvDevice->closeVMBusChannel();
-    _hvDevice->uninstallPacketActions();
-    OSSafeReleaseNULL(_hvDevice);
+    stop(provider);
   }
 
   return result;
@@ -104,11 +102,16 @@ void HyperVBalloon::stop(IOService *provider) {
   }
 
   if (_timerSource != nullptr) {
-    _workLoop->removeEventSource(_timerSource);
     _timerSource->cancelTimeout();
     OSSafeReleaseNULL(_timerSource);
   }
-  OSSafeReleaseNULL(_workLoop);
-  
+
+  if (_workLoop != nullptr) {
+    _workLoop->removeEventSource(_timerSource);
+    OSSafeReleaseNULL(_workLoop);
+  }
+
+  OSSafeReleaseNULL(_pageFrameNumberToMemoryDescriptorMap);
+
   super::stop(provider);
 }

--- a/MacHyperVSupport/Balloon/HyperVBalloon.hpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloon.hpp
@@ -19,14 +19,23 @@ class HyperVBalloon : public IOService {
   typedef IOService super;
 
 private:
-  HyperVVMBusDevice  *_hvDevice    = nullptr;
-  IOWorkLoop         *_workLoop    = nullptr;
-  IOTimerEventSource *_timerSource = nullptr;
-  UInt32             transactionId = 0;
+  HyperVVMBusDevice  *_hvDevice     = nullptr;
+  IOWorkLoop         *_workLoop     = nullptr;
+  IOTimerEventSource *_timerSource  = nullptr;
+  UInt32             _transactionId = 0;
+  UInt8              _balloonInflationSendBuffer[PAGE_SIZE];
+  OSDictionary       *_pageFrameNumberToMemoryDescriptorMap;
   
   void handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength);
+  void handleBalloonInflationRequest(HyperVDynamicMemoryMessageBalloonInflationRequest *request);
+  void handleBalloonDeflationRequest(HyperVDynamicMemoryMessageBalloonDeflationRequest *request);
+  void handleHotAddRequest(HyperVDynamicMemoryMessageHotAddRequest *request);
   bool setupBalloon();
+  bool doProtocolNegotitation(HyperVDynamicMemoryProtocolVersion version, bool isLastAttempt);
   IOReturn sendStatusReport(void*, void*, void*);
+  bool inflationBalloon(UInt32 pageCount, bool morePages);
+  static void getPagesStatus(UInt64 *availablePages);
+  static const OSSymbol *pageFrameNumberToString(UInt64 pfn);
   
 public:
   virtual bool start(IOService* provider) APPLE_KEXT_OVERRIDE;

--- a/MacHyperVSupport/Balloon/HyperVBalloon.hpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloon.hpp
@@ -19,13 +19,15 @@ class HyperVBalloon : public IOService {
   typedef IOService super;
 
 private:
-  HyperVVMBusDevice  *_hvDevice     = nullptr;
-  IOWorkLoop         *_workLoop     = nullptr;
-  IOTimerEventSource *_timerSource  = nullptr;
-  UInt32             _transactionId = 0;
-  UInt8              _balloonInflationSendBuffer[PAGE_SIZE];
-  OSDictionary       *_pageFrameNumberToMemoryDescriptorMap;
-  
+  HyperVVMBusDevice  *_hvDevice                             = nullptr;
+
+  IOWorkLoop         *_workLoop                             = nullptr;
+  IOTimerEventSource *_timerSource                          = nullptr;
+
+  UInt32              _transactionId                        = 0;
+  void               *_balloonInflationSendBuffer           = nullptr;
+  OSDictionary       *_pageFrameNumberToMemoryDescriptorMap = nullptr;
+
   void handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength);
   void handleBalloonInflationRequest(HyperVDynamicMemoryMessageBalloonInflationRequest *request);
   void handleBalloonDeflationRequest(HyperVDynamicMemoryMessageBalloonDeflationRequest *request);
@@ -34,7 +36,7 @@ private:
   bool setupBalloon();
   bool doProtocolNegotitation(HyperVDynamicMemoryProtocolVersion version, bool isLastAttempt);
   IOReturn sendStatusReport(void*, void*, void*);
-  bool inflationBalloon(UInt32 pageCount, bool morePages);
+  bool inflateBalloon(UInt32 pageCount, bool morePages);
   static UInt64 getPhysicalMemorySizeInPages();
   static void getPagesStatus(UInt64 *committedPages, UInt64 *usingPages);
   static const OSSymbol *pageFrameNumberToString(UInt64 pfn);

--- a/MacHyperVSupport/Balloon/HyperVBalloon.hpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloon.hpp
@@ -1,0 +1,35 @@
+//
+//  HyperVBalloon.hpp
+//  Hyper-V balloon driver interface
+//
+//  Copyright © 2022-2023 xdqi. All rights reserved.
+//
+
+#ifndef HyperVBalloon_hpp
+#define HyperVBalloon_hpp
+
+#include <IOKit/IOService.h>
+
+#include "HyperVVMBusDevice.hpp"
+#include "HyperVBalloonRegs.hpp"
+
+class HyperVBalloon : public IOService {
+  OSDeclareDefaultStructors(HyperVBalloon);
+  HVDeclareLogFunctionsVMBusChild("balloon");
+  typedef IOService super;
+
+private:
+  HyperVVMBusDevice  *_hvDevice    = nullptr;
+  IOWorkLoop         *_workLoop    = nullptr;
+  IOTimerEventSource *_timerSource = nullptr;
+  UInt32             transactionId = 0;
+  
+  void handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength);
+  bool setupBalloon();
+  IOReturn sendStatusReport(void*, void*, void*);
+  
+public:
+  virtual bool start(IOService* provider) APPLE_KEXT_OVERRIDE;
+  virtual void stop(IOService* provider) APPLE_KEXT_OVERRIDE;
+};
+#endif /* HyperVBalloon_hpp */

--- a/MacHyperVSupport/Balloon/HyperVBalloon.hpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloon.hpp
@@ -15,7 +15,7 @@
 
 class HyperVBalloon : public IOService {
   OSDeclareDefaultStructors(HyperVBalloon);
-  HVDeclareLogFunctionsVMBusChild("balloon");
+  HVDeclareLogFunctionsVMBusChild("ball");
   typedef IOService super;
 
 private:

--- a/MacHyperVSupport/Balloon/HyperVBalloon.hpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloon.hpp
@@ -35,7 +35,8 @@ private:
   bool doProtocolNegotitation(HyperVDynamicMemoryProtocolVersion version, bool isLastAttempt);
   IOReturn sendStatusReport(void*, void*, void*);
   bool inflationBalloon(UInt32 pageCount, bool morePages);
-  static void getPagesStatus(UInt64 *availablePages);
+  static UInt64 getPhysicalMemorySizeInPages();
+  static void getPagesStatus(UInt64 *committedPages, UInt64 *usingPages);
   static const OSSymbol *pageFrameNumberToString(UInt64 pfn);
   
 public:

--- a/MacHyperVSupport/Balloon/HyperVBalloon.hpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloon.hpp
@@ -30,6 +30,7 @@ private:
   void handleBalloonInflationRequest(HyperVDynamicMemoryMessageBalloonInflationRequest *request);
   void handleBalloonDeflationRequest(HyperVDynamicMemoryMessageBalloonDeflationRequest *request);
   void handleHotAddRequest(HyperVDynamicMemoryMessageHotAddRequest *request);
+  void handleInformationMessage(HyperVDynamicMemoryMessageInformation *info);
   bool setupBalloon();
   bool doProtocolNegotitation(HyperVDynamicMemoryProtocolVersion version, bool isLastAttempt);
   IOReturn sendStatusReport(void*, void*, void*);

--- a/MacHyperVSupport/Balloon/HyperVBalloonPrivate.cpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloonPrivate.cpp
@@ -316,16 +316,17 @@ void HyperVBalloon::handleBalloonDeflationRequest(HyperVDynamicMemoryMessageBall
 
   // we should send response until the last deflation message received
   if (request->morePages) return;
-  
+
   HyperVDynamicMemoryMessage message;
-  memset(&message, 0, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageBalloonDeflationResponse));
+  // deflation response is empty so we don't add sizeof (which in fact is 1) to message size
+  memset(&message, 0, sizeof(HyperVDynamicMemoryMessageHeader));
   message.header.type = kDynamicMemoryMessageTypeBalloonInflationResponse;
-  message.header.size = sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageBalloonDeflationResponse);
+  message.header.size = sizeof(HyperVDynamicMemoryMessageHeader);
   OSIncrementAtomic(&_transactionId);
   message.header.transactionId = _transactionId;
   
   HVDBGLOG("Sending deflation response");
-  if (!_hvDevice->writeInbandPacket(&message, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageBalloonDeflationResponse), false)) {
+  if (!_hvDevice->writeInbandPacket(&message, sizeof(HyperVDynamicMemoryMessageHeader), false)) {
     HVSYSLOG("Deflation response send failed");
   }
 }

--- a/MacHyperVSupport/Balloon/HyperVBalloonPrivate.cpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloonPrivate.cpp
@@ -164,10 +164,18 @@ void HyperVBalloon::getPagesStatus(UInt64 *committedPages, UInt64 *usingPages) {
   // compressor_page_count: "Compressed Memory"
   // active_page_count:     pages that is actively used
   if (committedPages) {
+#if defined(__i386__)
+    *committedPages = vmStat.wire_count + vmStat.active_count;
+#elif defined(__x86_64__)
     *committedPages = vmStat.wire_count + vmStat.internal_page_count + vmStat.compressor_page_count;
+#endif
   }
   if (usingPages) {
-    *usingPages = vmStat.wire_count + vmStat.active_count + vmStat.compressor_page_count;
+    *usingPages = vmStat.wire_count + vmStat.active_count
+#if defined(__x86_64__)
+    + vmStat.compressor_page_count
+#endif
+    ;
   }
 }
 
@@ -294,7 +302,6 @@ void HyperVBalloon::handleBalloonInflationRequest(HyperVDynamicMemoryMessageBall
       inflateBalloon(pageCount, false);
       pageCount = 0;
     }
-    break;
   }
 }
 

--- a/MacHyperVSupport/Balloon/HyperVBalloonPrivate.cpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloonPrivate.cpp
@@ -5,29 +5,265 @@
 //  Copyright © 2022-2023 xdqi. All rights reserved.
 //
 
+#include <string.h>
+#include <mach/vm_statistics.h>
+#include <kern/host.h>
+#include <sys/sysctl.h>
+
 #include "HyperVBalloon.hpp"
 #include "HyperVBalloonRegs.hpp"
 
 bool HyperVBalloon::setupBalloon() {
+  // We support Protocol 3.0 and 2.0
+  if (!doProtocolNegotitation(kHyperVDynamicMemoryProtocolVersion3, false) &&
+      !doProtocolNegotitation(kHyperVDynamicMemoryProtocolVersion2, true)) {
+    return false;
+  }
   
+  // Report capabilities to hypervisor
+  HyperVDynamicMemoryMessage message, protoResponse;
+  memset(&message, 0, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageCapabilitiesReport));
+  message.header.type = kDynamicMemoryMessageTypeCapabilitiesReport;
+  message.header.size = sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageCapabilitiesReport);
+  OSIncrementAtomic(&_transactionId);
+  message.header.transactionId = _transactionId;
+  message.capabilitiesReport.supportBalloon = 1; // We support balloon only
+  message.capabilitiesReport.supportHotAdd = 0; // macOS doesn't support memory hot adding.
+  message.capabilitiesReport.hotAddAlignment = 1;
+  message.capabilitiesReport.minimumPageCount = 0; // set the same as both Windows and Linux driver
+  message.capabilitiesReport.maximumPageNumber = -1;
+    
+  if (_hvDevice->writeInbandPacket(&message, message.header.size, true, &protoResponse, sizeof(protoResponse)) != kIOReturnSuccess) {
+    return false;
+  }
+
+  HVDBGLOG("Got dynamic memory capatibilities response of %u", protoResponse.capabilitiesResponse.isAccepted);
+  if (!protoResponse.capabilitiesResponse.isAccepted) {
+    return false;
+  }
+
+  _pageFrameNumberToMemoryDescriptorMap = OSDictionary::withCapacity(1024);
+  
+  return true;
+}
+
+bool HyperVBalloon::doProtocolNegotitation(HyperVDynamicMemoryProtocolVersion version, bool isLastAttempt) {
+  HyperVDynamicMemoryMessage message, protoResponse;
+  memset(&message, 0, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageProtocolRequest));
+  message.header.type = kDynamicMemoryMessageTypeProtocolRequest;
+  message.header.size = sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageProtocolRequest);
+  OSIncrementAtomic(&_transactionId);
+  message.header.transactionId = _transactionId;
+  message.protocolRequest.version = version;
+  message.protocolRequest.isLastAttempt = isLastAttempt;
+    
+  HVDBGLOG("Trying with dynamic memory protocol of %u.%u", version >> 16, version & 0xffff);
+  if (_hvDevice->writeInbandPacket(&message, message.header.size, true, &protoResponse, sizeof(protoResponse)) != kIOReturnSuccess) {
+    return false;
+  }
+
+  HVDBGLOG("Got dynamic memory protocol response of %u", protoResponse.protocolResponse.isAccepted);
+  if (!protoResponse.protocolResponse.isAccepted) {
+    return false;
+  }
+  
+  HVDBGLOG("Using dynamic memory protocol version of %u.%u", version >> 16, version & 0xffff);
   return true;
 }
 
 void HyperVBalloon::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength) {
   HyperVDynamicMemoryMessage *balloonMessage = (HyperVDynamicMemoryMessage*) pktData;
   
-  switch (balloonMessage->type) {
-    case kDynamicMemoryMessageTypeVersionResponse:
-      // handle it
+  switch (balloonMessage->header.type) {
+    case kDynamicMemoryMessageTypeProtocolResponse:
+    case kDynamicMemoryMessageTypeCapabilitiesResponse:
+      // We handled them in HyperVBalloon::start()
       break;
 
+    case kDynamicMemoryMessageTypeBalloonInflationRequest:
+      handleBalloonInflationRequest(&balloonMessage->inflationRequest);
+      break;
+  
+    case kDynamicMemoryMessageTypeBalloonDeflationRequest:
+      handleBalloonDeflationRequest(&balloonMessage->deflationRequest);
+      break;
+
+    case kDynamicMemoryMessageTypeHotAddRequest:
+      handleHotAddRequest(&balloonMessage->hotAddRequest);
+      break;
+
+    case kDynamicMemoryMessageTypeInfoMessage:
+      // We don't need to handle it, so intentionally break through
+      
     default:
-      HVDBGLOG("Unknown message type %u, size %u", balloonMessage->type, balloonMessage->size);
+      HVDBGLOG("Unknown message type %u, size %u", balloonMessage->header.type, balloonMessage->header.size);
       break;
   }
 }
 
-IOReturn sendStatusReport(void*, void*, void*) {
+IOReturn HyperVBalloon::sendStatusReport(void*, void*, void*) {
+  HyperVDynamicMemoryMessage message;
+  memset(&message, 0, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageStatusReport));
+  message.header.type = kDynamicMemoryMessageTypeStatusReport;
+  message.header.size = sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageStatusReport);
+  OSIncrementAtomic(&_transactionId);
+  message.header.transactionId = _transactionId;
+
+  UInt64 totalMemorySize;
+  size_t totalMemorySizeSize;
+  sysctlbyname("hw.memsize", &totalMemorySize, &totalMemorySizeSize, nullptr, 0);
+
+  // We just post two fields below, other fields are not needed by hypervisor
+  getPagesStatus(&message.statusReport.availablePages);
+  // macOS doesn't provide a way to calculate committed page in Windows speak, so simply
+  message.statusReport.committedPages = totalMemorySize - message.statusReport.availablePages;
   
-  return kIOReturnSuccess;
+  HVDBGLOG("Posting memory status report: available %llu, committed %llu", message.statusReport.availablePages, message.statusReport.committedPages);
+  
+  return _hvDevice->writeInbandPacket(&message, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageStatusReport), false);
+}
+
+void HyperVBalloon::getPagesStatus(UInt64 *availablePages) {
+  static host_t localHost = host_self();
+  static mach_msg_type_name_t vmStatSize;
+#if defined(__i386__)
+  static vm_statistics_data_t vmStat;
+  vmStatSize = HOST_VM_INFO_COUNT;
+  host_statistics(localHost, HOST_VM_INFO, (host_info_t) &vmStat, &vmStatSize);
+#elif defined(__x86_64__)
+  static vm_statistics64_data_t vmStat;
+  vmStatSize = HOST_VM_INFO64_COUNT;
+  host_statistics64(localHost, HOST_VM_INFO64, (host_info64_t) &vmStat, &vmStatSize);
+#else
+#error Unsupported arch
+#endif
+
+  // available = free + purgeable + pages that mmap-ing non-swap file
+  *availablePages = vmStat.free_count + vmStat.purgeable_count + vmStat.external_page_count;
+}
+
+void HyperVBalloon::handleHotAddRequest(HyperVDynamicMemoryMessageHotAddRequest *request) {
+  HyperVDynamicMemoryMessage message;
+  memset(&message, 0, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageHotAddResponse));
+  message.header.type = kDynamicMemoryMessageTypeHotAddResponse;
+  message.header.size = sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageHotAddResponse);
+  OSIncrementAtomic(&_transactionId);
+  message.header.transactionId = _transactionId;
+  
+  HVDBGLOG("Receiving hot add request");
+  
+  message.hotAddResponse.result = 1;    // success, meaning we processed the request successfully, so the host will not try to hot-add again
+  message.hotAddResponse.pageCount = 0; // of course we don't support hot-add.
+  
+  HVDBGLOG("Sending hot add response");
+  if (_hvDevice->writeInbandPacket(&message, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageHotAddResponse), false) != kIOReturnSuccess) {
+    HVDBGLOG("Hot add response send failed");
+  }
+}
+
+const OSSymbol* HyperVBalloon::pageFrameNumberToString(UInt64 pfn) {
+  unsigned char buffer[7] = {0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x0};
+  // 40-bit PFN encodes into null-terminated string in which every char has 7 effective bits (highest bit masked with 1)
+  buffer[0] |= pfn & 0x80;
+  buffer[1] |= (pfn >> 7) & 0x80;
+  buffer[2] |= (pfn >> 14) & 0x80;
+  buffer[3] |= (pfn >> 21) & 0x80;
+  buffer[4] |= (pfn >> 28) & 0x80;
+  buffer[5] |= (pfn >> 35) & 0x80;
+  buffer[6] = 0;
+  return OSSymbol::withCString((const char *) buffer);
+}
+
+bool HyperVBalloon::inflationBalloon(UInt32 pageCount, bool morePages) {
+  HyperVDynamicMemoryMessage *response = reinterpret_cast<HyperVDynamicMemoryMessage *>(_balloonInflationSendBuffer);
+  HVDBGLOG("This time inflate %lu pages and%s more", pageCount, morePages ? "" : " no");
+  // We have to do one page per allocation
+  // Hyper-V hypervisor will pass fragmented memory block to guest which macOS guest need to release
+  // while macOS doesn't support releasing part of a memory descriptor or splitting physical memory segment to indepedently relaseable parts
+  for (int i = 0; i < kHyperVDynamicMemoryBigChunkSize / PAGE_SIZE; ++i) {
+    // alloc memory in kernel
+    IOBufferMemoryDescriptor* chunk = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, kIODirectionInOut | kIOMemoryMapperNone | kIOMemoryPhysicallyContiguous, 1 * PAGE_SIZE, 1 * PAGE_SIZE);
+    chunk->prepare(kIODirectionInOut);
+  
+    IOByteCount physicalSegmentSize;
+    addr64_t physicalSegmentStart = chunk->getPhysicalSegment(0, &physicalSegmentSize, 0);
+    
+    // save (PFN, MemoryDescriptor) into map for further query
+    _pageFrameNumberToMemoryDescriptorMap->setObject(pageFrameNumberToString(physicalSegmentStart >> PAGE_SHIFT), chunk);
+    OSSafeReleaseNULL(chunk);
+
+    response->inflationResponse.ranges[i].startPageFrameNumber = physicalSegmentStart >> PAGE_SHIFT;
+    response->inflationResponse.ranges[i].pageCount = 1;
+    ++response->inflationResponse.rangeCount;
+  }
+  response->inflationResponse.morePages = morePages;
+  
+  // size = protocol header + inflation response header + memory ranges
+  IOReturn status;
+  do {
+    OSIncrementAtomic(&_transactionId);
+    response->header.transactionId = _transactionId;
+    HVDBGLOG("Send inflation request with %lu pages", response->inflationResponse.rangeCount);
+    status = _hvDevice->writeInbandPacket(response, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageBalloonInflationResponse) + sizeof(HyperVDynamicMemoryPageRange) * response->inflationResponse.rangeCount, false);
+  } while (status != kIOReturnSuccess);
+  
+  return true;
+}
+
+void HyperVBalloon::handleBalloonInflationRequest(HyperVDynamicMemoryMessageBalloonInflationRequest *request) {
+  UInt32 pageCount = request->pageCount;
+  UInt64 availablePages;
+  getPagesStatus(&availablePages);
+  
+  HVDBGLOG("Received request to inflate %lu pages", pageCount);
+  
+  if (availablePages < pageCount + kHyperVDynamicMemoryReservedPageCount) {
+    HVDBGLOG("We don't have enough memory for balloon, filling a part of requested");
+    pageCount = pageCount > kHyperVDynamicMemoryReservedPageCount ? (pageCount - kHyperVDynamicMemoryReservedPageCount) : 0;
+  }
+  
+  HVDBGLOG("We plan to inflate %lu pages", pageCount);
+  
+  HyperVDynamicMemoryMessage *message = reinterpret_cast<HyperVDynamicMemoryMessage *>(_balloonInflationSendBuffer);
+  memset(message, 0, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageBalloonInflationResponse));
+  message->header.type = kDynamicMemoryMessageTypeBalloonInflationResponse;
+  message->header.size = sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageBalloonInflationResponse);
+  
+  while (pageCount > 0) {
+    if (pageCount > kHyperVDynamicMemoryBigChunkSize) {
+      inflationBalloon(kHyperVDynamicMemoryBigChunkSize, true);
+    } else {
+      inflationBalloon(pageCount, false);
+    }
+  }
+}
+
+void HyperVBalloon::handleBalloonDeflationRequest(HyperVDynamicMemoryMessageBalloonDeflationRequest *request) {
+  for (int i = 0; i < request->rangeCount; ++i) {
+    for (int j = 0; j < request->ranges[i].pageCount; ++j) {
+      IOBufferMemoryDescriptor* chunk = static_cast<IOBufferMemoryDescriptor*>( _pageFrameNumberToMemoryDescriptorMap->getObject(pageFrameNumberToString(request->ranges[i].startPageFrameNumber + j)));
+      if (chunk) {
+        chunk->complete();
+        OSSafeReleaseNULL(chunk);
+        HVDBGLOG("Memory block %llu released", request->ranges[i].startPageFrameNumber + j);
+      } else {
+        HVDBGLOG("Memory block %llu not found", request->ranges[i].startPageFrameNumber + j);
+      }
+    }
+  }
+
+  // we should send response until the last deflation message received
+  if (request->morePages) return;
+  
+  HyperVDynamicMemoryMessage message;
+  memset(&message, 0, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageBalloonDeflationResponse));
+  message.header.type = kDynamicMemoryMessageTypeBalloonInflationResponse;
+  message.header.size = sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageBalloonDeflationResponse);
+  OSIncrementAtomic(&_transactionId);
+  message.header.transactionId = _transactionId;
+  
+  HVDBGLOG("Sending deflation response");
+  if (!_hvDevice->writeInbandPacket(&message, sizeof(HyperVDynamicMemoryMessageHeader) + sizeof(HyperVDynamicMemoryMessageBalloonDeflationResponse), false)) {
+    HVDBGLOG("Deflation response send failed");
+  }
 }

--- a/MacHyperVSupport/Balloon/HyperVBalloonPrivate.cpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloonPrivate.cpp
@@ -1,0 +1,33 @@
+//
+//  HyperVBalloonPrivate.cpp
+//  Hyper-V balloon driver internal implementation
+//
+//  Copyright © 2022-2023 xdqi. All rights reserved.
+//
+
+#include "HyperVBalloon.hpp"
+#include "HyperVBalloonRegs.hpp"
+
+bool HyperVBalloon::setupBalloon() {
+  
+  return true;
+}
+
+void HyperVBalloon::handlePacket(VMBusPacketHeader *pktHeader, UInt32 pktHeaderLength, UInt8 *pktData, UInt32 pktDataLength) {
+  HyperVDynamicMemoryMessage *balloonMessage = (HyperVDynamicMemoryMessage*) pktData;
+  
+  switch (balloonMessage->type) {
+    case kDynamicMemoryMessageTypeVersionResponse:
+      // handle it
+      break;
+
+    default:
+      HVDBGLOG("Unknown message type %u, size %u", balloonMessage->type, balloonMessage->size);
+      break;
+  }
+}
+
+IOReturn sendStatusReport(void*, void*, void*) {
+  
+  return kIOReturnSuccess;
+}

--- a/MacHyperVSupport/Balloon/HyperVBalloonRegs.hpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloonRegs.hpp
@@ -1,0 +1,136 @@
+//
+//  HyperVBalloonRegs.hpp
+//  Hyper-V balloon driver constants and structures
+//
+//  Copyright © 2022-2023 xdqi. All rights reserved.
+//
+
+#ifndef HyperVBalloonRegs_hpp
+#define HyperVBalloonRegs_hpp
+
+#define kHyperVDynamicMemoryBufferSize                      (16 * 1024)
+#define kHyperVDynamicMemoryResponsePacketSize              (2 * PAGE_SIZE)
+#define kHyperVDynamicMemoryStatusReportIntervalMilliseconds 1000
+
+//
+// Current dynamic memory protocol is 3.0 (Windows 10).
+// TODO: Support older protocol 2.0 (Windows 8) as well.
+//
+typedef enum : UInt32 {
+  kHyperVDynamicMemoryProtocolVersion1 = 0x10000,
+  kHyperVDynamicMemoryProtocolVersion2 = 0x20000,
+  kHyperVDynamicMemoryProtocolVersion3 = 0x30000
+} HyperVDynamicMemoryProtocolVersion;
+
+typedef enum : UInt16 {
+  kDynamicMemoryMessageTypeError                    = 0,
+  kDynamicMemoryMessageTypeVersionRequest           = 1,
+  kDynamicMemoryMessageTypeVersionResponse          = 2,
+  kDynamicMemoryMessageTypeCapabilitiesReport       = 3,
+  kDynamicMemoryMessageTypeCapabilitiesResponse     = 4,
+  kDynamicMemoryMessageTypeStatusReport             = 5,
+  kDynamicMemoryMessageTypeBalloonInflationRequest  = 6,
+  kDynamicMemoryMessageTypeBalloonInflationResponse = 7,
+  kDynamicMemoryMessageTypeBalloonDeflationRequest  = 8,
+  kDynamicMemoryMessageTypeBalloonDeflationResponse = 9,
+  kDynamicMemoryMessageTypeHotAddRequest            = 10,
+  kDynamicMemoryMessageTypeHotAddResponse           = 11,
+  kDynamicMemoryMessageTypeInfoMessage              = 12
+} HyperVDynamicMemoryMessageType;
+
+typedef struct __attribute__((packed)) {
+  UInt64 supportBalloon  : 1;
+  UInt64 supportHotAdd   : 1;
+  UInt64 hotAddAlignment : 4;
+  UInt64 reserved        : 58;
+} HyperVDynamicMemoryCapabilities; 
+
+typedef struct __attribute__((packed)) {
+  UInt64 startPageFrameNumber : 40;
+  UInt64 pageCount            : 24;
+} HyperVDynamicMemoryPageRange;
+
+typedef struct __attribute__((packed)) {
+  UInt32 version;
+  UInt32 isLastAttempt : 1;
+  UInt32 reserved      : 31;
+} HyperVDynamicMemoryMessageVersionRequest;
+
+typedef struct __attribute__((packed)) {
+  UInt64 isAccepted : 1;
+  UInt64 reserved   : 63;
+} HyperVDynamicMemoryMessageVersionResponse;
+
+typedef struct __attribute__((packed)) {
+  HyperVDynamicMemoryCapabilities capabilities;
+  UInt64                          minimumPageCount;
+  UInt64                          maximumPageNumber;
+} HyperVDynamicMemoryMessageCapabilitiesReport;
+
+typedef struct __attribute__((packed)) {
+  UInt64 isAccepted : 1;
+  UInt64 reserved   : 63;
+} HyperVDynamicMemoryMessageCapabilitiesResponse;
+
+typedef struct __attribute__((packed)) {
+  UInt64 availablePages;
+  UInt64 committedPages;
+  UInt64 pageFileSizeInPages;
+  UInt64 zeroAndFreePages;
+  UInt32 pageFileWritesInPages;
+  UInt32 ioDifference;
+} HyperVDynamicMemoryMessageStatusReport;
+
+typedef struct __attribute__((packed)) {
+  UInt32 pageCount;
+  UInt32 reserved;
+} HyperVDynamicMemoryMessageBalloonInflationRequest;
+
+typedef struct __attribute__((packed)) {
+  UInt32                       reserved;
+  UInt32                       morePages  : 1;
+  UInt32                       rangeCount : 31;
+  HyperVDynamicMemoryPageRange ranges[];
+} HyperVDynamicMemoryMessageBalloonInflationResponse;
+
+typedef struct __attribute__((packed)) {
+  UInt32                       reserved;
+  UInt32                       morePages  : 1;
+  UInt32                       rangeCount : 31;
+  HyperVDynamicMemoryPageRange ranges[];
+} HyperVDynamicMemoryMessageBalloonDeflationRequest;
+
+typedef struct __attribute__((packed)) {
+  // empty
+} HyperVDynamicMemoryMessageBalloonDeflationResponse;
+
+typedef struct __attribute__((packed)) {
+  HyperVMemoryPageRange ranges[];
+} HyperVDynamicMemoryMessageHotAddRequest;
+
+typedef struct __attribute__((packed)) {
+  UInt32 pageCount;
+  UInt32 result;
+} HyperVDynamicMemoryMessageHotAddResponse;
+
+typedef struct __attribute__((packed)) {
+  UInt16 type;
+  UInt16 size;
+  UInt32 transactionId;
+  
+  union {
+    HyperVDynamicMemoryMessageVersionRequest           versionRequest;
+    HyperVDynamicMemoryMessageVersionResponse          versionResponse;
+    HyperVDynamicMemoryMessageCapabilitiesReport       capabilitiesReport;
+    HyperVDynamicMemoryMessageCapabilitiesResponse     capabilitiesResponse;
+    HyperVDynamicMemoryMessageStatusReport             statusReport;
+    HyperVDynamicMemoryMessageBalloonInflationRequest  inflationRequest;
+    HyperVDynamicMemoryMessageBalloonInflationResponse inflationResponse;
+    HyperVDynamicMemoryMessageBalloonDeflationRequest  deflationRequest;
+    HyperVDynamicMemoryMessageBalloonDeflationResponse deflationResponse;
+    HyperVDynamicMemoryMessageHotAddRequest            hotAddRequest;
+    HyperVDynamicMemoryMessageHotAddResponse           hotAddResponse;
+  };
+} HyperVDynamicMemoryMessage;
+
+#endif /* HyperVBalloonRegs_hpp */

--- a/MacHyperVSupport/Balloon/HyperVBalloonRegs.hpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloonRegs.hpp
@@ -11,8 +11,14 @@
 #define kHyperVDynamicMemoryBufferSize                      (16 * 1024)
 #define kHyperVDynamicMemoryResponsePacketSize              (2 * PAGE_SIZE)
 #define kHyperVDynamicMemoryStatusReportIntervalMilliseconds 1000
-#define kHyperVDynamicMemoryReservedPageCount               (512 * 1024 * 1024 / PAGE_SIZE)
-#define kHyperVDynamicMemoryBigChunkSize                    (1 * 1024 * 1024)
+
+// Memory size that is reserved by guest regardless of memory usage
+#define kHyperVDynamicMemoryReservedMemorySize              (512 * 1024 * 1024)
+#define kHyperVDynamicMemoryReservedPageCount               (kHyperVDynamicMemoryReservedMemorySize / PAGE_SIZE)
+
+// Balloon max inflation size in one inflation response
+#define kHyperVDynamicMemoryInflationChunkSize              (2 * 1024 * 1024)
+#define kHyperVDynamicMemoryInflationChunkPageCount         (kHyperVDynamicMemoryInflationChunkSize / PAGE_SIZE)
 
 //
 // Current dynamic memory protocol is 3.0 (Windows 10).

--- a/MacHyperVSupport/Balloon/HyperVBalloonRegs.hpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloonRegs.hpp
@@ -45,6 +45,13 @@ typedef enum : UInt16 {
 } HyperVDynamicMemoryMessageType;
 
 //
+// Information type (see HyperVDynamicMemoryMessageInformation)
+//
+typedef enum : UInt32 {
+  kHyperVDynamicMemoryInformationTypeMaximumPageCount = 0
+} HyperVDynamicMemoryInformationType;
+
+//
 // a memory range in guest RAM physical address space
 //
 typedef struct __attribute__((packed)) {
@@ -172,6 +179,21 @@ typedef struct __attribute__((packed)) {
 } HyperVDynamicMemoryMessageHotAddResponse;
 
 //
+// Information message
+// RX
+//
+typedef struct __attribute__((packed)) {
+  UInt32                             reserved;
+  UInt32                             infoSize;
+  HyperVDynamicMemoryInformationType type;
+  UInt32                             dataSize;
+  union {
+    char                             data[];
+    UInt64                           number;
+  };
+} HyperVDynamicMemoryMessageInformation;
+
+//
 // All messages
 //
 typedef struct __attribute__((packed)) {
@@ -189,6 +211,7 @@ typedef struct __attribute__((packed)) {
     HyperVDynamicMemoryMessageBalloonDeflationResponse deflationResponse;
     HyperVDynamicMemoryMessageHotAddRequest            hotAddRequest;
     HyperVDynamicMemoryMessageHotAddResponse           hotAddResponse;
+    HyperVDynamicMemoryMessageInformation              information;
   };
 } HyperVDynamicMemoryMessage;
 

--- a/MacHyperVSupport/Balloon/HyperVBalloonRegs.hpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloonRegs.hpp
@@ -16,7 +16,8 @@
 
 //
 // Current dynamic memory protocol is 3.0 (Windows 10).
-// We support older protocol 2.0 (Windows 8) as well, as Gen2 VM may be running on Windows 8 / Server 2012 host
+// We support older protocol 2.0 (Windows 8) and protocol 1.0 (Windows 7)
+// It's weird that Hyper-V host running Windows 11 22H2 supports 2.0 but not 3.0, maybe supported in 23H1?
 //
 typedef enum : UInt32 {
   kHyperVDynamicMemoryProtocolVersion1 = 0x10000,

--- a/MacHyperVSupport/Balloon/HyperVBalloonRegs.hpp
+++ b/MacHyperVSupport/Balloon/HyperVBalloonRegs.hpp
@@ -153,9 +153,9 @@ typedef struct __attribute__((packed)) {
 // RX
 //
 typedef struct __attribute__((packed)) {
-  UInt32                       reserved;
   UInt32                       morePages  : 1;
-  UInt32                       rangeCount : 31;
+  UInt32                       reserved : 31;
+  UInt32                       rangeCount;
   HyperVDynamicMemoryPageRange ranges[];
 } HyperVDynamicMemoryMessageBalloonDeflationRequest;
 

--- a/MacHyperVSupport/Info.plist
+++ b/MacHyperVSupport/Info.plist
@@ -22,8 +22,6 @@
 	<dict>
 		<key>HyperVBalloon</key>
 		<dict>
-			<key>AbsoluteAxisBoundsRemovalPercentage</key>
-			<integer>0</integer>
 			<key>CFBundleIdentifier</key>
 			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			<key>HVType</key>

--- a/MacHyperVSupport/Info.plist
+++ b/MacHyperVSupport/Info.plist
@@ -20,6 +20,19 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>IOKitPersonalities</key>
 	<dict>
+		<key>HyperVBalloon</key>
+		<dict>
+			<key>AbsoluteAxisBoundsRemovalPercentage</key>
+			<integer>0</integer>
+			<key>CFBundleIdentifier</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>HVType</key>
+			<string>525074dc-8985-46e2-8057-a307dc18a502</string>
+			<key>IOClass</key>
+			<string>HyperVBalloon</string>
+			<key>IOProviderClass</key>
+			<string>HyperVVMBusDevice</string>
+		</dict>
 		<key>HyperVCPU</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Hi,

I'm working on basic ballooning support within this branch.
The current version just reports "memory demand" data to the host after negotiating the protocol with the host.

However, I encountered a problem I don't know how to solve.
By changing the line below to `message.capabilitiesReport.supportHotAdd = 1;`, the host will send a balloon request to the macOS guest minutes after protocol negotiation (weird Hyper-V protocol).
https://github.com/acidanthera/MacHyperVSupport/blob/d50c4e4430d1781f969cd0d9869a03194e507aff/MacHyperVSupport/Balloon/HyperVBalloonPrivate.cpp#L32
But it soon becomes a kernel panic, here's the [relevant kernel log](https://gist.github.com/xdqi/95eee257e540fba19a2f7dbbb24e2cfb).
https://github.com/acidanthera/MacHyperVSupport/blob/d50c4e4430d1781f969cd0d9869a03194e507aff/MacHyperVSupport/Balloon/HyperVBalloonPrivate.cpp#L265
It crashed immediately here at `HyperVVMBusDevice::writeRawPacketGated()`, so I don't have any clue about it.
I repeatedly confirmed that the buffer is valid.
If I remove the call above, it never crashes, so I believe my usage of `IOBufferMemoryDescriptor` is correct.
It could be either a flaw in `HyperVVMBusDevice` (unlikel), or something I don't know about XNU or Hyper-V.

Could you provide some help to me? I am a newbie to macOS kernel development.

Thank you and happy new year!